### PR TITLE
Fix/addplot in combochart

### DIFF
--- a/src/js/charts/lineAreaComboChart.js
+++ b/src/js/charts/lineAreaComboChart.js
@@ -229,6 +229,47 @@ var LineAreaComboChart = snippet.defineClass(ChartBase, /** @lends LineAreaCombo
 
         snippet.forEachArray(chartTypes, addDataRatio);
     },
+
+    /**
+     * Add plot line.
+     * @param {{index: number, color: string, id: string}} data - data
+     * @override
+     * @api
+     */
+    addPlotLine: function(data) {
+        this.componentManager.get('plot').addPlotLine(data);
+    },
+
+    /**
+     * Add plot band.
+     * @param {{range: Array.<number>, color: string, id: string}} data - data
+     * @override
+     * @api
+     */
+    addPlotBand: function(data) {
+        this.componentManager.get('plot').addPlotBand(data);
+    },
+
+    /**
+     * Remove plot line.
+     * @param {string} id - line id
+     * @override
+     * @api
+     */
+    removePlotLine: function(id) {
+        this.componentManager.get('plot').removePlotLine(id);
+    },
+
+    /**
+     * Remove plot band.
+     * @param {string} id - band id
+     * @override
+     * @api
+     */
+    removePlotBand: function(id) {
+        this.componentManager.get('plot').removePlotBand(id);
+    },
+
     /**
      * Render for zoom.
      * from chart/zoomMixer

--- a/src/js/components/axes/axis.js
+++ b/src/js/components/axes/axis.js
@@ -381,11 +381,12 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
     _renderTicks: function(size, tickCount, isNotDividedXAxis, additionalSize) {
         var tickColor = this.theme.tickColor;
         var axisData = this.data;
+        var fixedLastBlockInterval = axisData.fixedLastBlockInterval;
         var sizeRatio = axisData.sizeRatio || 1;
         var isYAxis = this.isYAxis;
         var isCenter = this.data.options.isCenter;
         var isPositionRight = this.data.isPositionRight;
-        var positions = calculator.makeTickPixelPositions((size * sizeRatio), tickCount);
+        var positions = calculator.makeTickPixelPositions((size * sizeRatio), tickCount, 0, fixedLastBlockInterval);
         var additionalHeight = this.paperAdditionalHeight + 1;
         var additionalWidth = this.paperAdditionalWidth;
 
@@ -402,6 +403,7 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
             additionalHeight: additionalHeight,
             isPositionRight: isPositionRight,
             tickColor: tickColor,
+            fixedLastBlockInterval: fixedLastBlockInterval,
             set: this.axisSet
         });
     },

--- a/src/js/components/axes/axis.js
+++ b/src/js/components/axes/axis.js
@@ -381,7 +381,7 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
     _renderTicks: function(size, tickCount, isNotDividedXAxis, additionalSize) {
         var tickColor = this.theme.tickColor;
         var axisData = this.data;
-        var fixedLastBlockIntervalPosition = (axisData.fixedLastBlockInterval) ? size : 0;
+        var remainLastBlockIntervalPosition = (axisData.remainLastBlockInterval) ? size : 0;
         var sizeRatio = axisData.sizeRatio || 1;
         var isYAxis = this.isYAxis;
         var isCenter = this.data.options.isCenter;
@@ -390,11 +390,11 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
             (size * sizeRatio),
             tickCount,
             0,
-            fixedLastBlockIntervalPosition
+            remainLastBlockIntervalPosition
         );
         var additionalHeight = this.paperAdditionalHeight + 1;
         var additionalWidth = this.paperAdditionalWidth;
-        var positionLength = (fixedLastBlockIntervalPosition) ? axisData.tickCount + 1 : axisData.tickCount;
+        var positionLength = remainLastBlockIntervalPosition ? axisData.tickCount + 1 : axisData.tickCount;
 
         positions.length = positionLength;
 
@@ -450,10 +450,12 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
     _renderLabelArea: function(size, tickCount, categories, additionalSize) {
         var sizeRatio = this.data.sizeRatio || 1;
         var axisData = this.data;
-        var fixedLastBlockIntervalPosition = (axisData.fixedLastBlockInterval) ? size : 0;
+        var remainLastBlockIntervalPosition = (axisData.remainLastBlockInterval) ? size : 0;
         var tickPixelPositions = calculator.makeTickPixelPositions(
-            (size * sizeRatio), tickCount,
-            0, fixedLastBlockIntervalPosition
+            (size * sizeRatio),
+            tickCount,
+            0,
+            remainLastBlockIntervalPosition
         );
         var labelDistance = tickPixelPositions[1] - tickPixelPositions[0];
 

--- a/src/js/components/axes/axis.js
+++ b/src/js/components/axes/axis.js
@@ -381,16 +381,22 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
     _renderTicks: function(size, tickCount, isNotDividedXAxis, additionalSize) {
         var tickColor = this.theme.tickColor;
         var axisData = this.data;
-        var fixedLastBlockInterval = axisData.fixedLastBlockInterval;
+        var fixedLastBlockIntervalPosition = (axisData.fixedLastBlockInterval) ? size : 0;
         var sizeRatio = axisData.sizeRatio || 1;
         var isYAxis = this.isYAxis;
         var isCenter = this.data.options.isCenter;
         var isPositionRight = this.data.isPositionRight;
-        var positions = calculator.makeTickPixelPositions((size * sizeRatio), tickCount, 0, fixedLastBlockInterval);
+        var positions = calculator.makeTickPixelPositions(
+            (size * sizeRatio),
+            tickCount,
+            0,
+            fixedLastBlockIntervalPosition
+        );
         var additionalHeight = this.paperAdditionalHeight + 1;
         var additionalWidth = this.paperAdditionalWidth;
+        var positionLength = (fixedLastBlockIntervalPosition) ? axisData.tickCount + 1 : axisData.tickCount;
 
-        positions.length = axisData.tickCount;
+        positions.length = positionLength;
 
         this.graphRenderer.renderTicks({
             paper: this.paper,
@@ -403,7 +409,6 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
             additionalHeight: additionalHeight,
             isPositionRight: isPositionRight,
             tickColor: tickColor,
-            fixedLastBlockInterval: fixedLastBlockInterval,
             set: this.axisSet
         });
     },
@@ -444,7 +449,12 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
      */
     _renderLabelArea: function(size, tickCount, categories, additionalSize) {
         var sizeRatio = this.data.sizeRatio || 1;
-        var tickPixelPositions = calculator.makeTickPixelPositions((size * sizeRatio), tickCount, 0);
+        var axisData = this.data;
+        var fixedLastBlockIntervalPosition = (axisData.fixedLastBlockInterval) ? size : 0;
+        var tickPixelPositions = calculator.makeTickPixelPositions(
+            (size * sizeRatio), tickCount,
+            0, fixedLastBlockIntervalPosition
+        );
         var labelDistance = tickPixelPositions[1] - tickPixelPositions[0];
 
         this._renderLabels(tickPixelPositions, categories, labelDistance, (additionalSize || 0));

--- a/src/js/helpers/calculator.js
+++ b/src/js/helpers/calculator.js
@@ -52,9 +52,10 @@ var calculator = {
      * @param {number} size area width or height
      * @param {number} count tick count
      * @param {?number} additionalPosition additional position
+     * @param {?number} fixedLastBlockInterval fixedLastBlockInterval
      * @returns {Array.<number>} positions
      */
-    makeTickPixelPositions: function(size, count, additionalPosition) {
+    makeTickPixelPositions: function(size, count, additionalPosition, fixedLastBlockInterval) {
         var positions = [];
 
         additionalPosition = additionalPosition || 0;
@@ -62,6 +63,10 @@ var calculator = {
         if (count > 0) {
             positions = snippet.map(snippet.range(0, count), function(index) {
                 var ratio = index === 0 ? 0 : (index / (count - 1));
+
+                if (fixedLastBlockInterval && count - 1 === index) {
+                    // console.log("SIZE", size);
+                }
 
                 return (ratio * size) + additionalPosition;
             });

--- a/src/js/helpers/calculator.js
+++ b/src/js/helpers/calculator.js
@@ -52,10 +52,10 @@ var calculator = {
      * @param {number} size area width or height
      * @param {number} count tick count
      * @param {?number} additionalPosition additional position
-     * @param {?number} fixedLastBlockIntervalPosition fixedLastBlockInterval position
+     * @param {?number} remainLastBlockIntervalPosition remainLastBlockInterval position
      * @returns {Array.<number>} positions
      */
-    makeTickPixelPositions: function(size, count, additionalPosition, fixedLastBlockIntervalPosition) {
+    makeTickPixelPositions: function(size, count, additionalPosition, remainLastBlockIntervalPosition) {
         var positions = [];
 
         additionalPosition = additionalPosition || 0;
@@ -69,8 +69,8 @@ var calculator = {
             positions[positions.length - 1] -= 1;
         }
 
-        if (fixedLastBlockIntervalPosition) {
-            positions.push(fixedLastBlockIntervalPosition);
+        if (remainLastBlockIntervalPosition) {
+            positions.push(remainLastBlockIntervalPosition);
         }
 
         return positions;
@@ -277,7 +277,8 @@ var sum = function(values) {
  */
 var divisors = function(value) {
     var result = [];
-    var a = 2, b;
+    var a = 2;
+    var b;
     for (; a * a <= value; a += 1) {
         if (value % a === 0) {
             b = value / a;

--- a/src/js/helpers/calculator.js
+++ b/src/js/helpers/calculator.js
@@ -52,10 +52,10 @@ var calculator = {
      * @param {number} size area width or height
      * @param {number} count tick count
      * @param {?number} additionalPosition additional position
-     * @param {?number} fixedLastBlockInterval fixedLastBlockInterval
+     * @param {?number} fixedLastBlockIntervalPosition fixedLastBlockInterval position
      * @returns {Array.<number>} positions
      */
-    makeTickPixelPositions: function(size, count, additionalPosition, fixedLastBlockInterval) {
+    makeTickPixelPositions: function(size, count, additionalPosition, fixedLastBlockIntervalPosition) {
         var positions = [];
 
         additionalPosition = additionalPosition || 0;
@@ -64,13 +64,13 @@ var calculator = {
             positions = snippet.map(snippet.range(0, count), function(index) {
                 var ratio = index === 0 ? 0 : (index / (count - 1));
 
-                if (fixedLastBlockInterval && count - 1 === index) {
-                    // console.log("SIZE", size);
-                }
-
                 return (ratio * size) + additionalPosition;
             });
             positions[positions.length - 1] -= 1;
+        }
+
+        if (fixedLastBlockIntervalPosition) {
+            positions.push(fixedLastBlockIntervalPosition);
         }
 
         return positions;
@@ -269,6 +269,31 @@ var sum = function(values) {
     });
 };
 
+/**
+ * Obtain the number of divisors.
+ * @memberOf module:calculator
+ * @param {Array.<number>} value target value
+ * @returns {number} result value
+ */
+var divisors = function(value) {
+    var result = [];
+    var a = 2, b;
+    for (; a * a <= value; a += 1) {
+        if (value % a === 0) {
+            b = value / a;
+            result.push(a);
+            if (b !== a) {
+                result.push(b);
+            }
+        }
+    }
+    result.sort(function(prev, next) {
+        return prev - next;
+    });
+
+    return result;
+};
+
 calculator.getDecimalLength = getDecimalLength;
 calculator.findMultipleNum = findMultipleNum;
 calculator.mod = mod;
@@ -276,6 +301,7 @@ calculator.add = add;
 calculator.subtract = subtract;
 calculator.multiply = multiply;
 calculator.divide = divide;
+calculator.divisors = divisors;
 calculator.sum = sum;
 
 module.exports = calculator;

--- a/src/js/models/scaleData/axisDataMaker.js
+++ b/src/js/models/scaleData/axisDataMaker.js
@@ -13,6 +13,9 @@ var calculator = require('../../helpers/calculator');
 var renderUtil = require('../../helpers/renderUtil');
 var arrayUtil = require('../../helpers/arrayUtil');
 var snippet = require('tui-code-snippet');
+var AUTO_INTERVAL_MIN_WIDTH = 90;
+var AUTO_INTERVAL_MAX_WIDTH = 121;
+var AUTO_INTERVAL_RANGE_STEP = 5;
 
 /**
  * Axis data maker.
@@ -191,7 +194,6 @@ var axisDataMaker = {
         var newBlockCount = parseInt(seriesWidth / blockSize, 10);
         // interval : number of previous blocks in a new block(spaces between tick and tick)
         var interval = parseInt(beforeBlockCount / newBlockCount, 10);
-
         var intervalInfo = null;
         var remainCount;
 
@@ -225,13 +227,13 @@ var axisDataMaker = {
      * @private
      */
     _makeCandidatesForAdjustingInterval: function(beforeBlockCount, seriesWidth) {
-        var self = this;
         var blockSizeRange;
+        var self = this;
         var candidates = [];
         var candidateInterval = calculator.divisors(beforeBlockCount);
         snippet.forEach(candidateInterval, function(interval) {
             var intervalWidth = (interval / beforeBlockCount) * seriesWidth;
-            if (intervalWidth >= 90 && intervalWidth <= 121) {
+            if (intervalWidth >= AUTO_INTERVAL_MIN_WIDTH && intervalWidth <= AUTO_INTERVAL_MAX_WIDTH) {
                 candidates.push({
                     blockCount: beforeBlockCount / interval,
                     interval: interval,
@@ -241,7 +243,7 @@ var axisDataMaker = {
         });
 
         if (candidates.length === 0) {
-            blockSizeRange = snippet.range(90, 121, 5);
+            blockSizeRange = snippet.range(AUTO_INTERVAL_MIN_WIDTH, AUTO_INTERVAL_MAX_WIDTH, AUTO_INTERVAL_RANGE_STEP);
             candidates = snippet.map(blockSizeRange, function(blockSize) {
                 return self._makeAdjustingIntervalInfo(beforeBlockCount, seriesWidth, blockSize);
             });
@@ -339,7 +341,7 @@ var axisDataMaker = {
             positionRatio: (startIndex / beforeBlockCount),
             sizeRatio: 1 - (beforeRemainBlockCount / beforeBlockCount),
             interval: interval,
-            fixedLastBlockInterval: beforeRemainBlockCount
+            remainLastBlockInterval: beforeRemainBlockCount
         });
     },
 

--- a/test/models/scaleData/axisDataMaker.spec.js
+++ b/test/models/scaleData/axisDataMaker.spec.js
@@ -204,7 +204,7 @@ describe('Test for axisDataMaker', function() {
 
     describe('_makeCandidatesForAdjustingInterval()', function() {
         it('should make 7 candidates which is ranged from 90px to 120px(90, 95, 100, 105, 110, 115, 120)', function() {
-            var actual = maker._makeCandidatesForAdjustingInterval(15, 300);
+            var actual = maker._makeCandidatesForAdjustingInterval(41, 300);
 
             expect(actual.length).toBe(7);
         });
@@ -213,7 +213,7 @@ describe('Test for axisDataMaker', function() {
             var actual;
 
             spyOn(maker, '_makeAdjustingIntervalInfo').and.returnValue(null);
-            actual = maker._makeCandidatesForAdjustingInterval(15, 300);
+            actual = maker._makeCandidatesForAdjustingInterval(41, 300);
 
             expect(actual.length).toBe(0);
         });
@@ -223,9 +223,9 @@ describe('Test for axisDataMaker', function() {
         it('should make adjust interval info according to currunt block count and series width', function() {
             var actual = maker._calculateAdjustingIntervalInfo(73, 400);
 
-            expect(actual.blockCount).toBe(3);
+            expect(actual.blockCount).toBe(4);
             expect(actual.beforeRemainBlockCount).toBe(1);
-            expect(actual.interval).toBe(24);
+            expect(actual.interval).toBe(18);
         });
 
         it('should return null, if there is no candidates', function() {
@@ -260,13 +260,11 @@ describe('Test for axisDataMaker', function() {
             };
             maker.updateLabelAxisDataForAutoTickInterval(axisData, 400, 0);
 
-            expect(axisData.tickCount).toBe(4);
+            expect(axisData.tickCount).toBe(5);
             expect(axisData.eventTickCount).toBe(20);
-            expect(axisData.labels).toEqual([20, 80, 140, 200]);
-            expect(axisData.startIndex).toBe(1);
-            expect(axisData.positionRatio).toBe(0.05263157894736842);
-            expect(axisData.sizeRatio).toBe(0.9473684210526316);
-            expect(axisData.interval).toBe(6);
+            expect(axisData.labels).toEqual([10, 50, 90, 130, 170, 200]);
+            expect(axisData.sizeRatio).toBe(0.8421052631578947);
+            expect(axisData.interval).toBe(4);
         });
     });
 


### PR DESCRIPTION
# Fixed work
- Intermittently, the start of the x-axis is not the first and last value of the raw data. #56
   (x축 레이브 시작값과 끝값이 raw data의 시작값, 끝값과 일치하지 않음)
![2018-03-20 10 09 37](https://user-images.githubusercontent.com/35218826/37630241-d38d6e58-2c26-11e8-91bf-b0e68d3342f1.png)

- AddPlot  from a function call in a combo chart do not work. #57
   (라인 에이러어 콤보차트에서 plotLine api 가 동작하지 않음)

# demo
- http://10.78.9.21:8082/examples/example08-03-combo-chart-line-and-area.html