### PR TITLE
fix: totals in the chart are sometimes out of the chart(fix #59)

### DIFF
--- a/src/js/models/scaleData/coordinateScaleCalculator.js
+++ b/src/js/models/scaleData/coordinateScaleCalculator.js
@@ -74,6 +74,7 @@ function getNormalizedStep(step) {
  * @param {number} min min
  * @param {number} max max
  * @param {number} step step
+ * @param {number} [showLabel] showLabel option
  * @private
  * @returns {{
  *     min: number,
@@ -81,13 +82,18 @@ function getNormalizedStep(step) {
  * }}
  * max = 155 and step = 10 ---> max = 160
  */
-function getNormalizedLimit(min, max, step) {
+function getNormalizedLimit(min, max, step, showLabel) {
     var minNumber = Math.min(getDigits(max), getDigits(step));
     var placeNumber = minNumber > 1 ? 1 : (1 / minNumber);
     var fixedStep = (step * placeNumber);
+    var noExtraMax = max;
 
     // ceil max value step digits
     max = Math.ceil((max * placeNumber) / fixedStep) * fixedStep / placeNumber;
+
+    if (showLabel && (fixedStep / 2) > (max - noExtraMax)) {
+        max += fixedStep;
+    }
 
     if (min > step) {
         // floor min value to multiples of step
@@ -121,13 +127,14 @@ function getNormalizedStepCount(limitSize, step) {
 /**
  * Get normalized scale data
  * @param {object} scale scale
+ * @param {number} [showLabel] showLabel option
  * @private
  * @returns {object}
  * @ignore
  */
-function getNormalizedScale(scale) {
+function getNormalizedScale(scale, showLabel) {
     var step = getNormalizedStep(scale.step);
-    var edge = getNormalizedLimit(scale.limit.min, scale.limit.max, step);
+    var edge = getNormalizedLimit(scale.limit.min, scale.limit.max, step, showLabel);
     var limitSize = Math.abs(edge.max - edge.min);
     var stepCount = getNormalizedStepCount(limitSize, step);
 
@@ -196,9 +203,10 @@ function coordinateScaleCalculator(options) {
     var offsetSize = options.offsetSize;
     var stepCount = options.stepCount;
     var minimumStepSize = options.minimumStepSize;
+    var showLabel = options.showLabel;
 
     var scale = getRoughScale(min, max, offsetSize, stepCount, minimumStepSize);
-    scale = getNormalizedScale(scale);
+    scale = getNormalizedScale(scale, showLabel);
 
     return scale;
 }

--- a/src/js/models/scaleData/coordinateScaleCalculator.js
+++ b/src/js/models/scaleData/coordinateScaleCalculator.js
@@ -87,11 +87,13 @@ function getNormalizedLimit(min, max, step, showLabel) {
     var placeNumber = minNumber > 1 ? 1 : (1 / minNumber);
     var fixedStep = (step * placeNumber);
     var noExtraMax = max;
+    var isNotEnoughSize = false;
 
     // ceil max value step digits
     max = Math.ceil((max * placeNumber) / fixedStep) * fixedStep / placeNumber;
+    isNotEnoughSize = fixedStep / 2 > max - noExtraMax;
 
-    if (showLabel && (fixedStep / 2) > (max - noExtraMax)) {
+    if (showLabel && isNotEnoughSize) {
         max += fixedStep;
     }
 

--- a/src/js/models/scaleData/scaleDataMaker.js
+++ b/src/js/models/scaleData/scaleDataMaker.js
@@ -284,7 +284,8 @@ var scaleDataMaker = {
             min: min,
             max: max,
             stepCount: stepCount,
-            offsetSize: baseSize
+            offsetSize: baseSize,
+            showLabel: options.showLabel
         });
 
         if (!options.useSpectrumLegend) {

--- a/src/js/models/scaleData/scaleDataModel.js
+++ b/src/js/models/scaleData/scaleDataModel.js
@@ -86,7 +86,8 @@ var ScaleDataModel = snippet.defineClass(/** @lends ScaleDataModel.prototype */{
         var options = snippet.extend(baseOptions, {
             isVertical: isVertical,
             limitOption: this._pickLimitOption(axisOptions),
-            tickCounts: additionalOptions.tickCounts
+            tickCounts: additionalOptions.tickCounts,
+            showLabel: this.options.series.showLabel
         });
 
         if (predicate.isBubbleChart(chartType)) {

--- a/test/models/scaleData/coordinateScaleCalculator.spec.js
+++ b/test/models/scaleData/coordinateScaleCalculator.spec.js
@@ -111,5 +111,16 @@ describe('coordinateScaleCalculator', function() {
             expect(scale.limit.min).toEqual(0);
             expect(scale.step).toEqual(0.2);
         });
+
+        it('using the showLabel option, the max value of sereis must be considered to the height of the label.', function() {
+            var scale = csc({
+                min: 0.01,
+                max: 0.47,
+                offsetSize: 196,
+                showLabel: true
+            });
+
+            expect(scale.limit.max).toEqual(2.6);
+        });
     });
 });


### PR DESCRIPTION
# Fixed work
- Sometimes the totals in the chart are sometimes out of the chart. #59
   (시리즈 영역의 showLabel 옵션이 true일때 Label이 시리즈 영역 밖으로 벗어나 보이는 부분 수정)
![2018-03-20 10 04 44](https://user-images.githubusercontent.com/35218826/37630144-274642d2-2c26-11e8-842a-55a5214261bb.png)


# demo
- http://10.78.9.21:8082/examples/example02-01-column-chart-basic.html