### PR TITLE
fix: error in group tooltip with no legend area (fix #51)

### DIFF
--- a/src/js/components/tooltips/groupTooltip.js
+++ b/src/js/components/tooltips/groupTooltip.js
@@ -147,13 +147,17 @@ var GroupTooltip = snippet.defineClass(TooltipBase, /** @lends GroupTooltip.prot
      */
     _updateLegendTheme: function(checkedLegends) {
         var colors = [];
+        var chartTypes = snippet.keys(this.originalTheme);
 
-        snippet.forEachArray(this.dataProcessor.getOriginalLegendData(), function(item) {
-            var _checkedLegends = checkedLegends[item.chartType] || checkedLegends;
-            if (_checkedLegends[item.index]) {
-                colors.push(item.theme.color);
-            }
-        });
+        snippet.forEachArray(chartTypes, function(chartType) {
+            var chartColors = this.originalTheme[chartType].colors;
+            snippet.forEachArray(chartColors, function(color, index) {
+                var _checkedLegends = checkedLegends[chartType] || checkedLegends;
+                if (_checkedLegends[index]) {
+                    colors.push(color);
+                }
+            }, this);
+        }, this);
 
         return {
             colors: colors

--- a/src/js/components/tooltips/tooltipBase.js
+++ b/src/js/components/tooltips/tooltipBase.js
@@ -8,6 +8,7 @@
 
 var snippet = require('tui-code-snippet');
 var raphael = require('raphael');
+var objectUtil = require('../../helpers/objectUtil');
 var chartConst = require('../../const'),
     dom = require('../../helpers/domHandler'),
     predicate = require('../../helpers/predicate'),
@@ -64,6 +65,12 @@ var TooltipBase = snippet.defineClass(/** @lends TooltipBase.prototype */ {
          * @type {object}
          */
         this.theme = params.theme;
+
+        /**
+         * Original Theme
+         * @type {object}
+         */
+        this.originalTheme = objectUtil.deepCopy(params.theme);
 
         /**
          * whether vertical or not

--- a/test/components/tooltips/groupTooltip.spec.js
+++ b/test/components/tooltips/groupTooltip.spec.js
@@ -115,6 +115,20 @@ describe('GroupTooltip', function() {
         });
     });
 
+    describe('_updateLegendTheme()', function() {
+        it('should return the theme colors reflecting the checkedLegends state.', function() {
+            var actual = {};
+            tooltip.originalTheme = {
+                line: {
+                    colors: ['red', 'blue', 'green', 'yellow']
+                }
+            };
+
+            actual = tooltip._updateLegendTheme([false, true, true, true]).colors;
+            expect(actual).toEqual(['blue', 'green', 'yellow']);
+        });
+    });
+
     describe('_makeItemRenderingData()', function() {
         it('should make series item model for series rendering.', function() {
             var actual, expected;


### PR DESCRIPTION
# Fixed work
- An error appears in the group tooltip with no legend area. #51 
(legend.visible 옵션이 false일때 그룹툴팁이 동작하지 않음)

# demo
- http://10.78.9.21:8082/examples/example02-04-column-chart-group-stack.html