### PR TITLE
fix: Spline only shows one chart in stacked area (fix #63)

### DIFF
--- a/src/js/plugins/raphaelLineChart.js
+++ b/src/js/plugins/raphaelLineChart.js
@@ -150,7 +150,9 @@ var RaphaelLineChart = snippet.defineClass(RaphaelLineBase, /** @lends RaphaelLi
         var self = this;
 
         return snippet.map(groupPositions, function(positions) {
-            return self._makeSplineLinesPath(positions, connectNulls);
+            return self._makeSplineLinesPath(positions, {
+                connectNulls: connectNulls
+            });
         });
     },
 

--- a/test/plugins/raphaelAreaChart.spec.js
+++ b/test/plugins/raphaelAreaChart.spec.js
@@ -95,21 +95,6 @@ describe('RaphaelAreaChart', function() {
         });
     });
 
-    describe('_makeSplineAreaBottomPath()', function() {
-        it('should create spline chart\'s bottom path by position', function() {
-            var actual, expected;
-
-            areaChart.zeroTop = 50;
-            actual = areaChart._makeSplineAreaBottomPath([{
-                left: 10
-            }, {
-                left: 30
-            }]);
-            expected = [['L', 30, 50], ['L', 10, 50]];
-            expect(actual).toEqual(expected);
-        });
-    });
-
     describe('_makeSplineAreaChartPath()', function() {
         it('should creat area, line path', function() {
             var actual, expected;
@@ -125,7 +110,7 @@ describe('RaphaelAreaChart', function() {
                 startTop: 50
             }]]);
             expected = [{
-                area: [['M', 10, 30, 'C', 10, 30], [30, 40, 30, 40], ['L', 30, 40], ['L', 30, 50], ['L', 30, 50], ['L', 10, 50]],
+                area: [['M', 10, 30, 'C', 10, 30], [30, 40, 30, 40], ['K', 30, 40], ['L', 30, 50], ['C', 30, 50], [10, 50, 10, 50], ['K', 10, 50], ['L', 10, 50]],
                 line: [['M', 10, 30, 'C', 10, 30], [30, 40, 30, 40]]
             }];
             expect(actual).toEqual(expected);
@@ -146,7 +131,7 @@ describe('RaphaelAreaChart', function() {
                 startTop: 50
             }]], hasExtraPath);
             expected = [{
-                area: [['M', 10, 30, 'C', 10, 30], [30, 40, 30, 40], ['L', 30, 50], ['L', 10, 50]],
+                area: [['M', 10, 30, 'C', 10, 30], [30, 40, 30, 40], ['C', 30, 50], [10, 50, 10, 50]],
                 line: [['M', 10, 30, 'C', 10, 30], [30, 40, 30, 40]]
             }];
             expect(actual).toEqual(expected);

--- a/test/plugins/raphaelLineTypeBase.spec.js
+++ b/test/plugins/raphaelLineTypeBase.spec.js
@@ -115,6 +115,61 @@ describe('RaphaelLineTypeBase', function() {
 
             expect(actual).toEqual(expected);
         });
+
+        it('"M" command should be removed if it is not the first line to start.', function() {
+            var actual = lineTypeBase._makeSplineLinesPath([
+                    {
+                        left: 87,
+                        top: 346,
+                        startTop: 346
+                    },
+                    {
+                        left: 334.5,
+                        top: 344.48,
+                        startTop: 346
+                    },
+                    {
+                        left: 582,
+                        top: 42,
+                        startTop: 346
+                    }
+                ], {
+                    isBeConnected: true
+                }),
+                expected = [['C', 87, 346],
+                    [222.8332650202649, 344.48, 334.5, 344.48, 446.1667349797351, 291.14518211369244],
+                    [582, 42, 582, 42]];
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('control values of the curve should be considered together with the direction in which the lines are drawn.', function() {
+            var actual = lineTypeBase._makeSplineLinesPath([
+                    {
+                        left: 582,
+                        top: 42,
+                        startTop: 346
+                    },
+                    {
+                        left: 87,
+                        top: 346,
+                        startTop: 346
+                    },
+                    {
+                        left: 334.5,
+                        top: 344.48,
+                        startTop: 346
+                    }
+                ], {
+                    isReverseDirection: true
+                }),
+                expected = [
+                    ['M', 582, 42, 'C', 582, 42],
+                    [18.97144613109832, 108.03284710173563, 87, 346, 52.985723065549166, 346],
+                    [334.5, 344.48, 334.5, 344.48]
+                ];
+            expect(actual).toEqual(expected);
+        });
     });
 
     describe('makeBorderStyle()', function() {


### PR DESCRIPTION
# Work
- Spline only shows one chart in stacked area demo #63
   (스텍 에어리어 차트의 spline옵션을 추가할 경우 값이 하나의 시리즈만 보이는 이슈 수정.)
![2018-03-22 4 41 22](https://user-images.githubusercontent.com/35218826/37757310-e7c46c08-2def-11e8-8816-68dad5f9341d.png)



# Demo
- http://10.78.9.21:8082/examples/example04-02-area-chart-normal-stack.html