### PR TITLE
fix: even if data is zero, the tooltip show for version 3.0.1

### DIFF
--- a/src/js/components/mouseEventDetectors/boundsBaseCoordinateModel.js
+++ b/src/js/components/mouseEventDetectors/boundsBaseCoordinateModel.js
@@ -265,17 +265,16 @@ var BoundsBaseCoordinateModel = snippet.defineClass(/** @lends BoundsBaseCoordin
                 included = false,
                 includedX, includedY;
 
-            if (bound.top === bound.bottom) {
-                bound.top -= chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
-                bound.bottom += chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
-            }
-
-            if (bound.left === bound.right) {
-                bound.left -= chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
-                bound.right += chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
-            }
-
             if (bound) {
+                if (bound.top === bound.bottom) {
+                    bound.top -= chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
+                    bound.bottom += chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
+                }
+                if (bound.left === bound.right) {
+                    bound.left -= chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
+                    bound.right += chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
+                }
+
                 includedX = bound.left <= layerX && bound.right >= layerX;
                 includedY = bound.top <= layerY && bound.bottom >= layerY;
                 included = includedX && includedY;

--- a/src/js/components/mouseEventDetectors/boundsBaseCoordinateModel.js
+++ b/src/js/components/mouseEventDetectors/boundsBaseCoordinateModel.js
@@ -265,6 +265,16 @@ var BoundsBaseCoordinateModel = snippet.defineClass(/** @lends BoundsBaseCoordin
                 included = false,
                 includedX, includedY;
 
+            if (bound.top === bound.bottom) {
+                bound.top -= chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
+                bound.bottom += chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
+            }
+
+            if (bound.left === bound.right) {
+                bound.left -= chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
+                bound.right += chartConst.SERIES_EXTRA_EVENT_AREA_FOR_ZERO;
+            }
+
             if (bound) {
                 includedX = bound.left <= layerX && bound.right >= layerX;
                 includedY = bound.top <= layerY && bound.bottom >= layerY;

--- a/src/js/components/series/columnChartSeries.js
+++ b/src/js/components/series/columnChartSeries.js
@@ -161,6 +161,7 @@ var ColumnChartSeries = snippet.defineClass(Series, /** @lends ColumnChartSeries
 
         return bound.left + ((bound.width - labelWidth + chartConst.TEXT_PADDING) / 2);
     }
+
 });
 
 BarTypeSeriesBase.mixin(ColumnChartSeries);

--- a/src/js/const.js
+++ b/src/js/const.js
@@ -97,6 +97,8 @@ var chartConst = {
     SERIES_AREA_V_PADDING: 10,
     /** series label padding */
     SERIES_LABEL_PADDING: 5,
+    /** series event margins for the value zero */
+    SERIES_EXTRA_EVENT_AREA_FOR_ZERO: 2,
     /** default font size of title */
     DEFAULT_TITLE_FONT_SIZE: 14,
     /** default font size of axis title */

--- a/src/js/plugins/raphaelBarChart.js
+++ b/src/js/plugins/raphaelBarChart.js
@@ -15,7 +15,7 @@ var EMPHASIS_OPACITY = 1;
 var DE_EMPHASIS_OPACITY = 0.3;
 var DEFAULT_LUMINANC = 0.2;
 var BAR_HOVER_SPARE_SIZE = 8;
-var SERIES_EXTRA_VISUAL_AREA_FOR_ZERO = 1;
+var SERIES_EXTRA_VISUAL_AREA_FOR_ZERO = 2;
 var SERIES_EXTRA_VISUAL_OPACITY_FOR_ZERO = 0.4;
 
 /**
@@ -344,8 +344,8 @@ var RaphaelBarChart = snippet.defineClass(/** @lends RaphaelBarChart.prototype *
      */
     _animateRect: function(rect, bound) {
         rect.animate({
-            x: bound.width ? bound.left : bound.left - SERIES_EXTRA_VISUAL_AREA_FOR_ZERO,
-            y: bound.height ? bound.top : bound.top - SERIES_EXTRA_VISUAL_AREA_FOR_ZERO,
+            x: bound.width ? bound.left : bound.left - (SERIES_EXTRA_VISUAL_AREA_FOR_ZERO / 2),
+            y: bound.height ? bound.top : bound.top - (SERIES_EXTRA_VISUAL_AREA_FOR_ZERO / 2),
             width: bound.width ? bound.width : SERIES_EXTRA_VISUAL_AREA_FOR_ZERO,
             height: bound.height ? bound.height : SERIES_EXTRA_VISUAL_AREA_FOR_ZERO,
             opacity: (bound.height && bound.width) ? 1 : SERIES_EXTRA_VISUAL_OPACITY_FOR_ZERO

--- a/src/js/plugins/raphaelBarChart.js
+++ b/src/js/plugins/raphaelBarChart.js
@@ -15,6 +15,8 @@ var EMPHASIS_OPACITY = 1;
 var DE_EMPHASIS_OPACITY = 0.3;
 var DEFAULT_LUMINANC = 0.2;
 var BAR_HOVER_SPARE_SIZE = 8;
+var SERIES_EXTRA_VISUAL_AREA_FOR_ZERO = 1;
+var SERIES_EXTRA_VISUAL_OPACITY_FOR_ZERO = 0.4;
 
 /**
  * @classdesc RaphaelBarChart is graph renderer for bar, column chart.
@@ -342,10 +344,11 @@ var RaphaelBarChart = snippet.defineClass(/** @lends RaphaelBarChart.prototype *
      */
     _animateRect: function(rect, bound) {
         rect.animate({
-            x: bound.left,
-            y: bound.top,
-            width: bound.width,
-            height: bound.height
+            x: bound.width ? bound.left : bound.left - SERIES_EXTRA_VISUAL_AREA_FOR_ZERO,
+            y: bound.height ? bound.top : bound.top - SERIES_EXTRA_VISUAL_AREA_FOR_ZERO,
+            width: bound.width ? bound.width : SERIES_EXTRA_VISUAL_AREA_FOR_ZERO,
+            height: bound.height ? bound.height : SERIES_EXTRA_VISUAL_AREA_FOR_ZERO,
+            opacity: (bound.height && bound.width) ? 1 : SERIES_EXTRA_VISUAL_OPACITY_FOR_ZERO
         }, ANIMATION_DURATION, '>');
     },
 

--- a/test/components/mouseEventDetectors/boundsBaseCoordinateModel.spec.js
+++ b/test/components/mouseEventDetectors/boundsBaseCoordinateModel.spec.js
@@ -384,6 +384,42 @@ describe('Test for BoundsBaseCoordinateModel', function() {
 
             expect(actual).toEqual(expected);
         });
+
+        it('top and bottom are the same, there should be an empty event space.', function() {
+            var data = [
+                {
+                    bound: {
+                        left: 10,
+                        top: 25,
+                        right: 20,
+                        bottom: 25
+                    }
+                }
+            ];
+            var layerX = 15;
+            var layerY = 23;
+            var actual = coordinateModel._findCandidates(data, layerX, layerY).length;
+
+            expect(actual).toBe(1);
+        });
+
+        it('left and right are the same, there should be an empty event space.', function() {
+            var data = [
+                {
+                    bound: {
+                        left: 10,
+                        top: 20,
+                        right: 10,
+                        bottom: 30
+                    }
+                }
+            ];
+            var layerX = 8;
+            var layerY = 25;
+            var actual = coordinateModel._findCandidates(data, layerX, layerY).length;
+
+            expect(actual).toBe(1);
+        });
     });
 
     describe('findData()', function() {

--- a/test/plugins/raphaelBarChart.spec.js
+++ b/test/plugins/raphaelBarChart.spec.js
@@ -234,7 +234,7 @@ describe('RaphaelBarChart', function() {
     });
 
     describe('_animateRect()', function() {
-        it('should draw 1px even if width is 0.', function() {
+        it('should draw 2px even if width is 0.', function() {
             var rect = {
                 animate: function() {}
             };
@@ -248,10 +248,10 @@ describe('RaphaelBarChart', function() {
 
             barChart._animateRect(rect, bound);
 
-            expect(rect.animate.calls.mostRecent().args[0].width).toBe(1);
+            expect(rect.animate.calls.mostRecent().args[0].width).toBe(2);
         });
 
-        it('should draw 1px even if height is 0.', function() {
+        it('should draw 2px even if height is 0.', function() {
             var rect = {
                 animate: function() {}
             };
@@ -265,7 +265,7 @@ describe('RaphaelBarChart', function() {
 
             barChart._animateRect(rect, bound);
 
-            expect(rect.animate.calls.mostRecent().args[0].height).toBe(1);
+            expect(rect.animate.calls.mostRecent().args[0].height).toBe(2);
         });
     });
 });

--- a/test/plugins/raphaelBarChart.spec.js
+++ b/test/plugins/raphaelBarChart.spec.js
@@ -232,4 +232,40 @@ describe('RaphaelBarChart', function() {
             expect(actual.left).toBeDefined();
         });
     });
+
+    describe('_animateRect()', function() {
+        it('should draw 1px even if width is 0.', function() {
+            var rect = {
+                animate: function() {}
+            };
+            var bound = {
+                left: 10,
+                top: 10,
+                width: 0,
+                height: 10
+            };
+            spyOn(rect, 'animate');
+
+            barChart._animateRect(rect, bound);
+
+            expect(rect.animate.calls.mostRecent().args[0].width).toBe(1);
+        });
+
+        it('should draw 1px even if height is 0.', function() {
+            var rect = {
+                animate: function() {}
+            };
+            var bound = {
+                left: 10,
+                top: 10,
+                width: 10,
+                height: 0
+            };
+            spyOn(rect, 'animate');
+
+            barChart._animateRect(rect, bound);
+
+            expect(rect.animate.calls.mostRecent().args[0].height).toBe(1);
+        });
+    });
 });


### PR DESCRIPTION
## Fixed work
-   If data is 0, the tooltip is not visible.(bar타입 차트에서 데이터가 0인 series는 tooltip이 보이지 않음) #73 
- 값이 0일때 event detector 의 이벤트 감지 바운더리를 앞 뒤로 2px붙여줌.
- 값이 0일때 보이지 않던 컬럼 bar를 희미하게 보이도록 수정.

## Demo
- http://10.78.9.21:8082/examples/example01-01-bar-chart-basic.html
- http://10.78.9.21:8082/examples/example02-01-column-chart-basic.html