### PR TITLE
fix: Axis tick label alignment, when label is rotated (#31)

### DIFF
--- a/src/js/components/axes/axis.js
+++ b/src/js/components/axes/axis.js
@@ -462,7 +462,7 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
         var theme = this.theme.label;
         var degree = this.data.degree;
         var halfWidth = labelSize / 2;
-        var forEdgeAlignWidth = labelSize / 8;
+        var edgeAlignWidth = labelSize / chartConst.AXIS_EDGE_RATIO;
         var horizontalTop = this.layout.position.top + chartConst.X_AXIS_LABEL_PADDING;
         var baseLeft = this.layout.position.left;
         var labelMargin = this.options.labelMargin || 0;
@@ -476,7 +476,7 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
                 positionTopAndLeft.left = labelSize + labelMargin;
             } else {
                 positionTopAndLeft.top = horizontalTop + labelMargin;
-                positionTopAndLeft.left = baseLeft + labelPosition + forEdgeAlignWidth;
+                positionTopAndLeft.left = baseLeft + labelPosition + edgeAlignWidth;
             }
 
             renderer.renderRotatedLabel({

--- a/src/js/components/axes/axis.js
+++ b/src/js/components/axes/axis.js
@@ -462,6 +462,7 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
         var theme = this.theme.label;
         var degree = this.data.degree;
         var halfWidth = labelSize / 2;
+        var forEdgeAlignWidth = labelSize / 8;
         var horizontalTop = this.layout.position.top + chartConst.X_AXIS_LABEL_PADDING;
         var baseLeft = this.layout.position.left;
         var labelMargin = this.options.labelMargin || 0;
@@ -475,11 +476,7 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
                 positionTopAndLeft.left = labelSize + labelMargin;
             } else {
                 positionTopAndLeft.top = horizontalTop + labelMargin;
-                positionTopAndLeft.left = baseLeft + labelPosition - theme.fontSize;
-
-                if (this.isLabelAxis) {
-                    positionTopAndLeft.left += halfWidth;
-                }
+                positionTopAndLeft.left = baseLeft + labelPosition + forEdgeAlignWidth;
             }
 
             renderer.renderRotatedLabel({

--- a/src/js/const.js
+++ b/src/js/const.js
@@ -379,6 +379,7 @@ var chartConst = {
      * Last standard multiple num of axis
      */
     AXIS_LAST_STANDARD_MULTIPLE_NUM: 100,
+    AXIS_EDGE_RATIO: 8,
     /** label padding top */
     LABEL_PADDING_TOP: 7,
     /** line margin top */

--- a/src/js/const.js
+++ b/src/js/const.js
@@ -368,8 +368,6 @@ var chartConst = {
      * @type {string}
      */
     YAXIS_ALIGN_CENTER: 'center',
-    /** xAxis label compare margin */
-    XAXIS_LABEL_COMPARE_MARGIN: 20,
     /** xAxis label gutter */
     XAXIS_LABEL_GUTTER: 2,
     /**

--- a/src/js/models/scaleData/axisDataMaker.js
+++ b/src/js/models/scaleData/axisDataMaker.js
@@ -463,10 +463,9 @@ var axisDataMaker = {
 
         snippet.forEachArray(chartConst.DEGREE_CANDIDATES, function(degree) {
             var compareWidth = geomatric.calculateRotatedWidth(degree, labelWidth, labelHeight);
-
             foundDegree = degree;
 
-            if (compareWidth <= labelAreaWidth + chartConst.XAXIS_LABEL_COMPARE_MARGIN) {
+            if (compareWidth <= labelAreaWidth) {
                 return false;
             }
 

--- a/test/models/scaleData/axisDataMaker.spec.js
+++ b/test/models/scaleData/axisDataMaker.spec.js
@@ -375,7 +375,7 @@ describe('Test for axisDataMaker', function() {
         it('find rotation degree', function() {
             var actual = maker._findRotationDegree(50, 60, 20);
 
-            expect(actual).toBe(25);
+            expect(actual).toBe(65);
         });
 
         it('max degree is 85', function() {
@@ -431,7 +431,7 @@ describe('Test for axisDataMaker', function() {
             );
 
             expect(actual).toEqual({
-                degree: 25,
+                degree: 45,
                 overflowHeight: 10,
                 overflowLeft: -40,
                 overflowRight: -70

--- a/test/models/scaleData/axisDataMaker.spec.js
+++ b/test/models/scaleData/axisDataMaker.spec.js
@@ -378,7 +378,7 @@ describe('Test for axisDataMaker', function() {
             expect(actual).toBe(65);
         });
 
-        it('max degree is 85', function() {
+        it('labelAreaWidth is too short to represent the label, the angle must be a maximum value of 85 degrees', function() {
             var actual = maker._findRotationDegree(5, 120, 20);
 
             expect(actual).toBe(85);


### PR DESCRIPTION
## Fixed work
-  [Axis tick label alignment, when label is rotated](https://github.nhnent.com/fe/tui.chart/issues/664) #31
- x축 레이블이 카테고리 타입일 경우 가운데 정렬해 주던 부분의 코드 제거
- rotate의 변경 기준에서 XAXIS_LABEL_COMPARE_MARGIN 값을 더해주던 부분을 제거
  (레이블이 왼쪽으로 정렬되면서 x축 첫번째 레이블의 시작점이 잘리는 현상이 생기는 이유로 rotate기준을 엄격하게 변경)

## Demo
- http://10.78.9.21:8082/examples/example04-01-area-chart-basic.html