### PR TITLE
Fix/diverging tick

### DIFF
--- a/src/js/components/axes/axis.js
+++ b/src/js/components/axes/axis.js
@@ -385,6 +385,7 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
         var sizeRatio = axisData.sizeRatio || 1;
         var isYAxis = this.isYAxis;
         var isCenter = this.data.options.isCenter;
+        var isDivided = this.data.options.divided;
         var isPositionRight = this.data.isPositionRight;
         var positions = calculator.makeTickPixelPositions(
             (size * sizeRatio),
@@ -404,9 +405,11 @@ var Axis = snippet.defineClass(/** @lends Axis.prototype */ {
             positions: positions,
             isVertical: isYAxis,
             isCenter: isCenter,
+            isDivided: isDivided,
             additionalSize: additionalSize,
             additionalWidth: additionalWidth,
             additionalHeight: additionalHeight,
+            otherSideDimension: this._getOtherSideDimension(),
             isPositionRight: isPositionRight,
             tickColor: tickColor,
             set: this.axisSet

--- a/src/js/plugins/raphaelAxisComponent.js
+++ b/src/js/plugins/raphaelAxisComponent.js
@@ -179,17 +179,19 @@ var RaphaelAxisComponent = snippet.defineClass(/** @lends RaphaelAxisComponent.p
         var additionalSize = data.additionalSize;
         var isVertical = data.isVertical;
         var isCenter = data.isCenter;
+        var isDivided = data.isDivided;
         var isPositionRight = data.isPositionRight;
         var tickColor = data.tickColor;
         var layout = data.layout;
         var rightEdgeOfAxis = layout.position.left + layout.dimension.width;
         var baseTop = layout.position.top;
         var baseLeft = layout.position.left;
+        var centerAxisWidth = isDivided ? data.otherSideDimension.width : 0;
         var tick;
         var isContainDivensionArea = function(position) {
             var compareType = isVertical ? 'height' : 'width';
 
-            return (position > layout.dimension[compareType]);
+            return (position > layout.dimension[compareType] + centerAxisWidth);
         };
 
         snippet.forEach(positions, function(position) {

--- a/test/plugins/raphaelAxisComponent.spec.js
+++ b/test/plugins/raphaelAxisComponent.spec.js
@@ -60,6 +60,13 @@ describe('RaphaelAxisComponent', function() {
 
             expect(raphaelAxisComponent.ticks.length).toBe(5);
         });
+        it('tick count should be calculated taking into account the width of the axis where the y-axis is centered', function() {
+            data.positions = [200, 400, 800, 900, 1000, 1200];
+            data.isDivided = true;
+            raphaelAxisComponent.renderTicks(data);
+
+            expect(raphaelAxisComponent.ticks.length).toBe(5);
+        });
     });
 
     describe('calculatePosition() ', function() {


### PR DESCRIPTION
## Fixed work
- no x-axis tick in the diverging chart where y-axis alignment is center. #80
  (y축이 가운데 정렬인 차트의 x축 tick이 전부 나오지 않음)
- ![2018-04-05 6 32 30](https://user-images.githubusercontent.com/35218826/38358261-bc94f136-38ff-11e8-8045-a70bb2ec21e3.png)
## Demo
- http://10.78.9.21:8082/examples/example01-05-bar-chart-diverging-and-center-yaxis.html

