### PR TITLE
fix: title align anchor bug

### DIFF
--- a/src/js/components/title/title.js
+++ b/src/js/components/title/title.js
@@ -91,9 +91,8 @@ class Title {
      * @private
      */
     _renderTitleArea(data) {
-        const {paper, dimensionMap: {legend, series}} = data;
-        const legendWidth = legend ? legend.width : 0;
-        const chartWidth = series.width + legendWidth;
+        const {paper, dimensionMap} = data;
+        const chartTitleAreaWidth = this._calculateForTitleAreaWidth(dimensionMap);
 
         return this.graphRenderer.render({
             paper,
@@ -101,8 +100,22 @@ class Title {
             offset: this.offset,
             theme: this.theme,
             align: this.align,
-            chartWidth
+            chartTitleAreaWidth
         });
+    }
+
+    /**
+     * Calculate title area width
+     * @param {object} dimensionMap dimensionMap
+     *     @param {object} dimensionMap.chartExportMenu dimension of chartExportMenu
+     *     @param {object} dimensionMap.chart chart of chartExportMenu
+     * @returns {number} title area width
+     * @private
+     */
+    _calculateForTitleAreaWidth({chartExportMenu, chart}) {
+        const exportMenuWidth = chartExportMenu ? (chartExportMenu.width * 2) : 0;
+
+        return chart.width - exportMenuWidth;
     }
 }
 

--- a/src/js/plugins/raphaelTitleComponent.js
+++ b/src/js/plugins/raphaelTitleComponent.js
@@ -15,7 +15,7 @@ export default class RaphaelTitleComponent {
      *   @param {{x: number, y: number}} renderInfo.offset - title offset x, y
      *   @param {object} renderInfo.theme - theme object
      *   @param {string} [renderInfo.align] - title align option
-     *   @param {number} renderInfo.chartWidth chart width
+     *   @param {number} renderInfo.chartTitleAreaWidth chart title area width
      * @returns {Array.<object>} title set
      */
     render(renderInfo) {
@@ -25,19 +25,24 @@ export default class RaphaelTitleComponent {
             offset,
             theme,
             align = chartConst.TITLE_ALIGN_LEFT,
-            chartWidth
+            chartTitleAreaWidth
         } = renderInfo;
-        const {fontSize, fontFamily} = theme.fontSize;
+        const {fontSize, fontFamily} = theme;
         const titleSize = raphaelRenderUtil.getRenderedTextSize(titleText, fontSize, fontFamily);
         const titleSet = paper.set();
-        const pos = this.getTitlePosition(titleSize, align, chartWidth, offset);
+        const pos = this.getTitlePosition(titleSize, align, chartTitleAreaWidth, offset);
+        const textAnchor = {
+            left: 'start',
+            right: 'end',
+            center: 'middle'
+        }[align];
 
         titleSet.push(raphaelRenderUtil.renderText(paper, pos, titleText, {
             'font-family': theme.fontFamily,
             'font-size': theme.fontSize,
             'font-weight': theme.fontWeight,
             fill: theme.color,
-            'text-anchor': 'start'
+            'text-anchor': textAnchor
         }));
 
         return titleSet;
@@ -54,10 +59,20 @@ export default class RaphaelTitleComponent {
     getTitlePosition(titleSize, align, chartWidth, offset) {
         let left;
 
+        /*
+        if (align === chartConst.TITLE_ALIGN_CENTER) {
+            left = (chartWidth / 2) - (titleSize.width / 2);
+        } else if (align === chartConst.TITLE_ALIGN_RIGHT) {
+            left = chartWidth - titleSize.width;
+        } else {
+            left = chartConst.CHART_PADDING;
+        }
+        */
+
         if (align === chartConst.TITLE_ALIGN_CENTER) {
             left = chartWidth / 2;
         } else if (align === chartConst.TITLE_ALIGN_RIGHT) {
-            left = chartWidth - titleSize.width - (titleSize.width / 2);
+            left = chartWidth;
         } else {
             left = chartConst.CHART_PADDING;
         }

--- a/src/js/plugins/raphaelTitleComponent.js
+++ b/src/js/plugins/raphaelTitleComponent.js
@@ -31,18 +31,18 @@ export default class RaphaelTitleComponent {
         const titleSize = raphaelRenderUtil.getRenderedTextSize(titleText, fontSize, fontFamily);
         const titleSet = paper.set();
         const pos = this.getTitlePosition(titleSize, align, chartTitleAreaWidth, offset);
-        const textAnchor = {
+        const textAnchorAlign = {
             left: 'start',
             right: 'end',
             center: 'middle'
-        }[align];
+        };
 
         titleSet.push(raphaelRenderUtil.renderText(paper, pos, titleText, {
             'font-family': theme.fontFamily,
             'font-size': theme.fontSize,
             'font-weight': theme.fontWeight,
             fill: theme.color,
-            'text-anchor': textAnchor
+            'text-anchor': textAnchorAlign[align]
         }));
 
         return titleSet;
@@ -58,16 +58,6 @@ export default class RaphaelTitleComponent {
      */
     getTitlePosition(titleSize, align, chartWidth, offset) {
         let left;
-
-        /*
-        if (align === chartConst.TITLE_ALIGN_CENTER) {
-            left = (chartWidth / 2) - (titleSize.width / 2);
-        } else if (align === chartConst.TITLE_ALIGN_RIGHT) {
-            left = chartWidth - titleSize.width;
-        } else {
-            left = chartConst.CHART_PADDING;
-        }
-        */
 
         if (align === chartConst.TITLE_ALIGN_CENTER) {
             left = chartWidth / 2;

--- a/test/plugins/raphaelTitleComponent.spec.js
+++ b/test/plugins/raphaelTitleComponent.spec.js
@@ -12,7 +12,7 @@ describe('RaphaelTitleComponent', () => {
             };
             const actual = raphaelTitleComponent.getTitlePosition(titleSize, 'center', 300, offset).left;
 
-            expect(actual).toBe(150);
+            expect(actual).toBe(130);
         });
 
         it('position should have a value with the align right state applied.', () => {
@@ -23,7 +23,7 @@ describe('RaphaelTitleComponent', () => {
             };
             const actual = raphaelTitleComponent.getTitlePosition(titleSize, 'right', 300, offset).left;
 
-            expect(actual).toBe(240);
+            expect(actual).toBe(260);
         });
 
         it('position should have a value with the align left state applied.', () => {

--- a/test/plugins/raphaelTitleComponent.spec.js
+++ b/test/plugins/raphaelTitleComponent.spec.js
@@ -12,7 +12,7 @@ describe('RaphaelTitleComponent', () => {
             };
             const actual = raphaelTitleComponent.getTitlePosition(titleSize, 'center', 300, offset).left;
 
-            expect(actual).toBe(130);
+            expect(actual).toBe(150);
         });
 
         it('position should have a value with the align right state applied.', () => {
@@ -23,7 +23,7 @@ describe('RaphaelTitleComponent', () => {
             };
             const actual = raphaelTitleComponent.getTitlePosition(titleSize, 'right', 300, offset).left;
 
-            expect(actual).toBe(260);
+            expect(actual).toBe(300);
         });
 
         it('position should have a value with the align left state applied.', () => {


### PR DESCRIPTION
## work
- title 정렬이 제대로 안되는 부분 수정.
- title의 포지션 left, center, right 의 text-anchor를 각각 start, middle, end로 변경.
- chartWidth 구하는 공식 변경

## demo
- (center 정렬 )http://10.78.9.21:8082/examples/example01-01-bar-chart-basic.html
- (right 정렬 )http://10.78.9.21:8082/examples/example07-03-pie-chart-outer-legend.html