### PR TITLE
fix: label overlap when autoInterval option is true

### DIFF
--- a/src/js/components/axes/axis.js
+++ b/src/js/components/axes/axis.js
@@ -519,10 +519,12 @@ class Axis {
         const {labelMargin = 0, pointOnColumn, isCenter} = this.options;
         const isLineTypeChart = predicate.isLineTypeChart(dataProcessor.chartType, dataProcessor.seriesTypes);
         const isPointOnColumn = isLineTypeChart && pointOnColumn;
+        const isAutoTickInterval = predicate.isAutoTickInterval(this.options.tickInterval);
 
         positions.forEach((position, index) => {
             const labelPosition = position + additionalSize;
             const halfLabelDistance = labelSize / 2;
+            const isOverLapXAxisLabel = this._isOverLapXAxisLabel(categories[index], position, positions[index + 1]);
             let positionTopAndLeft = {};
             /*
              * to prevent printing `undefined` text, when category label is not set
@@ -538,6 +540,8 @@ class Axis {
                     halfLabelDistance,
                     isPositionRight
                 });
+            } else if (isAutoTickInterval && isOverLapXAxisLabel) {
+                return;
             } else {
                 positionTopAndLeft = this._getXAxisLabelPosition(layout, {
                     labelMargin,
@@ -565,6 +569,21 @@ class Axis {
                 theme
             });
         }, this);
+    }
+
+    /**
+     * @param {string} labelText - axis label text
+     * @param {number} position - current left position
+     * @param {number} nextPosition - next  left position
+     * @returns {boolean}
+     */
+    _isOverLapXAxisLabel(labelText, position, nextPosition) {
+        const labelWidth = renderUtil.getRenderedLabelWidth(labelText);
+        if (nextPosition && nextPosition - position < labelWidth) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/js/components/axes/axis.js
+++ b/src/js/components/axes/axis.js
@@ -526,10 +526,11 @@ class Axis {
             const halfLabelDistance = labelSize / 2;
             const isOverLapXAxisLabel = this._isOverLapXAxisLabel(categories[index], position, positions[index + 1]);
             let positionTopAndLeft = {};
+
             /*
              * to prevent printing `undefined` text, when category label is not set
              */
-            if (labelPosition < 0) {
+            if (labelPosition < 0 || (!isYAxis && isAutoTickInterval && isOverLapXAxisLabel)) {
                 return;
             }
 
@@ -540,8 +541,6 @@ class Axis {
                     halfLabelDistance,
                     isPositionRight
                 });
-            } else if (isAutoTickInterval && isOverLapXAxisLabel) {
-                return;
             } else {
                 positionTopAndLeft = this._getXAxisLabelPosition(layout, {
                     labelMargin,
@@ -579,7 +578,7 @@ class Axis {
      */
     _isOverLapXAxisLabel(labelText, position, nextPosition) {
         const labelWidth = renderUtil.getRenderedLabelWidth(labelText);
-        if (nextPosition && nextPosition - position < labelWidth) {
+        if (!snippet.isUndefined(nextPosition) && (nextPosition - position < labelWidth)) {
             return true;
         }
 

--- a/test/components/axes/axis.spec.js
+++ b/test/components/axes/axis.spec.js
@@ -204,6 +204,20 @@ describe('Test for Axis', () => {
 
             expect(labelPosition.top).toBe(67);
         });
+
+        it('renderLabel should not occur when the tickInterval option is auto and the tick labels overlap.', () => {
+            spyOn(axis.graphRenderer, 'renderLabel');
+            spyOn(axis, '_isOverLapXAxisLabel').and.returnValue(true);
+
+            axis.options = {
+                labelMargin: 30,
+                tickInterval: 'auto'
+            };
+            axis.isYAxis = false;
+            axis._renderNormalLabels([0], ['abc'], 0, 0);
+
+            expect(axis.graphRenderer.renderLabel).not.toHaveBeenCalled();
+        });
     });
 
     describe('_renderRotationLabels()', () => {


### PR DESCRIPTION
## work
- tickInterval 옵션이 auto이면서  마지막 tick이 이전 tick과 너무 붙어 있을때 label이 겹쳐보이는 현상
- label 크기보다 tick간격이 짧을경우 이전 레이블 출력을 생략하여 주도록 변경
## demo
- http://10.78.9.21:8081/examples/example08-03-combo-chart-line-and-area.html