### PR TITLE
fix: radial chart tooltip and dot bug (fix #105)

### DIFF
--- a/src/js/components/tooltips/normalTooltip.js
+++ b/src/js/components/tooltips/normalTooltip.js
@@ -9,6 +9,7 @@ import chartConst from '../../const';
 import predicate from '../../helpers/predicate';
 import tooltipTemplate from './tooltipTemplate';
 import snippet from 'tui-code-snippet';
+const DEFALUT_TOOLTIP_COLOR = '#aaa';
 
 /**
  * @classdesc NormalTooltip component.
@@ -156,18 +157,16 @@ class NormalTooltip extends TooltipBase {
 
     /**
      * Find data for tooltip
-     * @param {string} chartType - chart type
+     * @param {string} hoveredChartType - chart type
      * @param {{groupIndex: number, index: number}} indexes - indexes
      * @param {Object} data - data for tooltip render
      * @returns {string} color hex string
      * @private
      */
-    _findTooltipColor(chartType, indexes, data) {
-        const isbar = predicate.isBarTypeChart(this.chartType);
-        const isboxplot = predicate.isBoxplotChart(this.chartType);
-        const colorByPoint = (
-            (isbar || isboxplot) && this.dataProcessor.options.series.colorByPoint
-        );
+    _findTooltipColor(hoveredChartType, indexes, data) {
+        const isBar = predicate.isBarTypeChart(this.chartType);
+        const isBoxplot = predicate.isBoxplotChart(this.chartType);
+        const colorByPoint = (isBar || isBoxplot) && this.dataProcessor.options.series.colorByPoint;
 
         const {groupIndex} = indexes;
         let {index: seriesIndex} = indexes;
@@ -178,7 +177,7 @@ class NormalTooltip extends TooltipBase {
             seriesIndex = data.tooltipColorIndex;
         }
 
-        return colorByPoint ? '#aaa' : this.tooltipColors[chartType][seriesIndex];
+        return colorByPoint ? DEFALUT_TOOLTIP_COLOR : this.tooltipColors[hoveredChartType][seriesIndex];
     }
 
     /**

--- a/src/js/components/tooltips/tooltipBase.js
+++ b/src/js/components/tooltips/tooltipBase.js
@@ -366,7 +366,6 @@ export default class TooltipBase {
                 top: tooltipElement.offsetTop
             };
         }
-
         this._showTooltip(tooltipElement, params, prevPosition);
     }
 

--- a/src/js/plugins/raphaelLineTypeBase.js
+++ b/src/js/plugins/raphaelLineTypeBase.js
@@ -5,6 +5,7 @@
  */
 import raphaelRenderUtil from './raphaelRenderUtil';
 import renderUtil from '../helpers/renderUtil';
+import predicate from '../helpers/predicate';
 import arrayUtil from '../helpers/arrayUtil';
 import snippet from 'tui-code-snippet';
 
@@ -509,9 +510,10 @@ export default class RaphaelLineTypeBase {
      * @param {{groupIndex: number, index:number}} data show info
      */
     showAnimation(data) {
-        const index = data.groupIndex;
         const groupIndex = data.index;
-        const item = this.groupDots[groupIndex][index];
+        const groupDot = this.groupDots[groupIndex];
+        const item = this._findDotItem(groupDot, data.groupIndex);
+
         let line = this.groupLines ? this.groupLines[groupIndex] : this.groupAreas[groupIndex];
         let strokeWidth, startLine;
 
@@ -538,6 +540,23 @@ export default class RaphaelLineTypeBase {
         if (item.startDot) {
             this._showDot(item.startDot, groupIndex);
         }
+    }
+
+    /**
+     * Find dot item
+     * @param {Array.<Object>} groupDot - groupDot info
+     * @param {number} index - dot index
+     * @returns {Object} - raphael object
+     * @private
+     */
+    _findDotItem(groupDot = [], index) {
+        const isRadialChart = predicate.isRadialChart(this.chartType);
+
+        if (isRadialChart && groupDot.length === index) {
+            index = 0;
+        }
+
+        return groupDot[index];
     }
 
     /**
@@ -651,14 +670,14 @@ export default class RaphaelLineTypeBase {
         const index = data.groupIndex; // Line chart has pivot values.
         const groupIndex = data.index;
         const groupDot = this.groupDots[groupIndex];
+        const item = this._findDotItem(groupDot, index);
+
         let line, strokeWidth, startLine;
         let opacity = this.dotOpacity;
 
-        if (!groupDot || !groupDot[index]) {
+        if (!item) {
             return;
         }
-
-        const item = groupDot[index];
 
         line = this.groupLines ? this.groupLines[groupIndex] : this.groupAreas[groupIndex];
 

--- a/src/js/plugins/raphaelLineTypeBase.js
+++ b/src/js/plugins/raphaelLineTypeBase.js
@@ -552,6 +552,7 @@ export default class RaphaelLineTypeBase {
     _findDotItem(groupDot = [], index) {
         const isRadialChart = predicate.isRadialChart(this.chartType);
 
+        // For radial charts, the position path is one more than the length of the data.
         if (isRadialChart && groupDot.length === index) {
             index = 0;
         }

--- a/test/components/tooltips/normalTooltip.spec.js
+++ b/test/components/tooltips/normalTooltip.spec.js
@@ -193,4 +193,26 @@ describe('NormalTooltip', () => {
             expect(actual).toBe(expected);
         });
     });
+
+    describe('_findTooltipData()', () => {
+        it('groupIndex that is equal to the length of the data in the radial chart, you should look for the groupIndex at position 0.', () => {
+            tooltip.data = {
+                'radial': [[
+                    {category: 'Silver', label: '10', legend: 'Density1'},
+                    {category: 'Silver', label: '20', legend: 'Density2'}
+                ],
+                [
+                    {category: 'Silver', label: '30', legend: 'Density3'},
+                    {category: 'Silver', label: '40', legend: 'Density4'}
+                ]]
+            };
+
+            const actual = tooltip._findTooltipData('radial', {
+                groupIndex: 2,
+                index: 1
+            });
+
+            expect(actual).toEqual({category: 'Silver', label: '20', legend: 'Density2'});
+        });
+    });
 });

--- a/test/plugins/raphaelLineTypeBase.spec.js
+++ b/test/plugins/raphaelLineTypeBase.spec.js
@@ -245,4 +245,18 @@ describe('RaphaelLineTypeBase', () => {
             expect(dotSetArgs.stroke).toBe('#D95576');
         });
     });
+
+    describe('_findDotItem()', () => {
+        it('index that is equal to the length of the data in the radial chart, you should look for the index at position 0.', () => {
+            lineTypeBase.chartType = 'radial';
+
+            const data = [
+                'item1', 'item2'
+            ];
+            const index = data.length;
+            const actual = lineTypeBase._findDotItem(data, index);
+
+            expect(actual).toBe('item1');
+        });
+    });
 });


### PR DESCRIPTION
## work
- #105 radial 차트에 첫번째 값이 툴팁 데이터 값이 깨집니다.
- 방사형 차트의 포지션 값의 마지막 포지션에 해당하는 데이터 값은 실질적으로 index 0 에 해당하는 값임으로
   마지막 position 인 경우 데이터를 찾을때는 index 0의 데이터 값을 찾도록 변경함.

- _makeSingleTooltipHtml 메소드의 기능을 새로운 메소드로 분리해 함수 복잡도를 낮춤.

## demo
- http://10.78.9.21:8082/examples/example13-01-radial-chart-basic.html