### PR TITLE
Feat/diverging yaxis

### DIFF
--- a/src/js/charts/barChart.js
+++ b/src/js/charts/barChart.js
@@ -35,8 +35,6 @@ class BarChart extends ChartBase {
          * @type {string}
          */
         this.className = 'tui-bar-chart';
-
-        this._updateOptionsRelatedDiverging(options);
     }
 
     /**

--- a/src/js/charts/barChart.js
+++ b/src/js/charts/barChart.js
@@ -44,7 +44,9 @@ class BarChart extends ChartBase {
      * @param {object} options - options
      * @private
      */
-    _updateOptionsRelatedDiverging(options) {
+    _updateOptionsRelatedDiverging() {
+        const {options} = this;
+
         options.series = options.series || {};
 
         /**
@@ -75,6 +77,8 @@ class BarChart extends ChartBase {
      * @override
      */
     addComponents() {
+        this._updateOptionsRelatedDiverging();
+
         this.componentManager.register('title', 'title');
         this.componentManager.register('plot', 'plot');
         this.componentManager.register('legend', 'legend');

--- a/src/js/charts/barChart.js
+++ b/src/js/charts/barChart.js
@@ -39,11 +39,10 @@ class BarChart extends ChartBase {
 
     /**
      * Update options related diverging option.
-     * @param {object} options - options
      * @private
      */
     _updateOptionsRelatedDiverging() {
-        const {options} = this;
+        const options = this.options; // eslint-disable-line
 
         options.series = options.series || {};
 

--- a/test/charts/barChart.spec.js
+++ b/test/charts/barChart.spec.js
@@ -11,7 +11,6 @@ describe('Test for BarChart', () => {
 
     describe('constructor()', () => {
         beforeEach(() => {
-            // spyOn(BarChart.prototype, '_updateOptionsRelatedDiverging');
             spyOn(BarChart.prototype, '_initializeOptions');
             spyOn(BarChart.prototype, '_createComponentManager').and.returnValue({
                 register: jasmine.createSpy('register')
@@ -23,24 +22,7 @@ describe('Test for BarChart', () => {
             barInstance = new BarChart({
                 categories: ['cate1', 'cate2', 'cate3'],
                 series: {
-                    'chartType': [
-                        {
-                            name: 'Legend1',
-                            data: [20, 30, 50]
-                        },
-                        {
-                            name: 'Legend2',
-                            data: [40, 40, 60]
-                        },
-                        {
-                            name: 'Legend3',
-                            data: [60, 50, 10]
-                        },
-                        {
-                            name: 'Legend4',
-                            data: [80, 10, 70]
-                        }
-                    ]
+                    'chartType': []
                 }
             }, {
                 title: {

--- a/test/charts/barChart.spec.js
+++ b/test/charts/barChart.spec.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Test for BubbleChart.
+ * @author NHN Ent.
+ *         FE Development Lab <dl_javascript@nhnent.com>
+ */
+
+import BarChart from '../../src/js/charts/barChart';
+
+describe('Test for BarChart', () => {
+    let barInstance;
+
+    describe('constructor()', () => {
+        beforeEach(() => {
+            // spyOn(BarChart.prototype, '_updateOptionsRelatedDiverging');
+            spyOn(BarChart.prototype, '_initializeOptions');
+            spyOn(BarChart.prototype, '_createComponentManager').and.returnValue({
+                register: jasmine.createSpy('register')
+            });
+
+            BarChart.prototype.options = {
+                chartType: 'bar'
+            };
+            barInstance = new BarChart({
+                categories: ['cate1', 'cate2', 'cate3'],
+                series: {
+                    'chartType': [
+                        {
+                            name: 'Legend1',
+                            data: [20, 30, 50]
+                        },
+                        {
+                            name: 'Legend2',
+                            data: [40, 40, 60]
+                        },
+                        {
+                            name: 'Legend3',
+                            data: [60, 50, 10]
+                        },
+                        {
+                            name: 'Legend4',
+                            data: [80, 10, 70]
+                        }
+                    ]
+                }
+            }, {
+                title: {
+                    fontSize: 14
+                }
+            }, {});
+        });
+
+        it('After the instance is created, the hasRightYAxis property must be set.', () => {
+            expect(barInstance.hasRightYAxis).toBe(false);
+        });
+    });
+});

--- a/test/charts/barChart.spec.js
+++ b/test/charts/barChart.spec.js
@@ -32,7 +32,7 @@ describe('Test for BarChart', () => {
         });
 
         it('After the instance is created, the hasRightYAxis property must be set.', () => {
-            expect(barInstance.hasRightYAxis).toBe(false);
+            expect(barInstance.hasRightYAxis).toEqual(jasmine.any(Boolean));
         });
     });
 });


### PR DESCRIPTION
## work
- diverging 차트의 , yAxis추가 옵션이 있음에도, rightYAxis가 생기지 않는다.
- es6 적용 과정에서 addComponent() 호출과 _updateOptionsRelatedDiverging() 호출 순서가 바뀌면서hasRightYAxis 프로퍼티가 생기지 않게됨.
- 부모 클래스에서 _updateOptionsRelatedDiverging() 호출이 적절한 시점에 되게하여 hasRightYAxis 프로퍼티가 정상적으로 생기게 함

## demo
- http://10.78.9.21:8082/examples/example01-04-bar-chart-diverging.html