### PR TITLE
Fix/bullet chart resize

### DIFF
--- a/examples/example15-01-bullet-chart-basic.html
+++ b/examples/example15-01-bullet-chart-basic.html
@@ -52,16 +52,6 @@ var data = {
         data: 11,
         markers: [20],
         ranges: [[0, 8], [8, 15]]
-    }, {
-        name: 'World',
-        data: 30,
-        markers: [25],
-        ranges: [[0, 10], [10, 19], [19, 28]]
-    }, {
-        name: 'Income',
-        data: 23,
-        markers: [],
-        ranges: [[19, 25], [13, 19], [0, 13]]
     }]
 };
 var options = {
@@ -96,7 +86,32 @@ var theme = {
 tui.chart.registerTheme('myTheme', theme);
 options.theme = 'myTheme';
 
-tui.chart.bulletChart(container, data, options);
+var chart = tui.chart.bulletChart(container, data, options);
+
+ setTimeout(function(){
+     chart.resize({
+         width: document.body.offsetWidth
+         // height: document.body.offsetHeight
+     });
+ }, 2000);
+
+ setTimeout(function(){
+     chart.resize({
+         width: 500
+         // height: document.body.offsetHeight
+     });
+ }, 4000);
+
+window.onresize = function(event) {
+     chart.resize({
+         width: document.body.offsetWidth
+         // height: document.body.offsetHeight
+     });
+};
+
+ /*
+ */
+
 </script>
 
 <!--For tutorial page-->

--- a/examples/example15-01-bullet-chart-basic.html
+++ b/examples/example15-01-bullet-chart-basic.html
@@ -52,6 +52,16 @@ var data = {
         data: 11,
         markers: [20],
         ranges: [[0, 8], [8, 15]]
+    }, {
+        name: 'World',
+        data: 30,
+        markers: [25],
+        ranges: [[0, 10], [10, 19], [19, 28]]
+    }, {
+        name: 'Income',
+        data: 23,
+        markers: [],
+        ranges: [[19, 25], [13, 19], [0, 13]]
     }]
 };
 var options = {
@@ -86,32 +96,7 @@ var theme = {
 tui.chart.registerTheme('myTheme', theme);
 options.theme = 'myTheme';
 
-var chart = tui.chart.bulletChart(container, data, options);
-
- setTimeout(function(){
-     chart.resize({
-         width: document.body.offsetWidth
-         // height: document.body.offsetHeight
-     });
- }, 2000);
-
- setTimeout(function(){
-     chart.resize({
-         width: 500
-         // height: document.body.offsetHeight
-     });
- }, 4000);
-
-window.onresize = function(event) {
-     chart.resize({
-         width: document.body.offsetWidth
-         // height: document.body.offsetHeight
-     });
-};
-
- /*
- */
-
+tui.chart.bulletChart(container, data, options);
 </script>
 
 <!--For tutorial page-->

--- a/src/js/plugins/raphaelBulletChart.js
+++ b/src/js/plugins/raphaelBulletChart.js
@@ -30,6 +30,7 @@ class RaphaelBulletChart {
      * @returns {Array.<object>} seriesSet
      */
     render(paper, data) {
+        console.log('a');
         const {groupBounds, seriesDataModel} = data;
 
         if (!groupBounds || !groupBounds.length) {
@@ -47,6 +48,8 @@ class RaphaelBulletChart {
         this.seriesDataModel = seriesDataModel;
         this.maxRangeCount = seriesDataModel.maxRangeCount;
         this.maxMarkerCount = seriesDataModel.maxMarkerCount;
+
+        this._graphColors = [];
 
         this.rangeOpacities = {};
 
@@ -290,8 +293,6 @@ class RaphaelBulletChart {
         this.groupBounds = groupBounds;
         this.resizeClipRect(width, height);
         this.paper.setSize(width, height);
-
-        this._renderBounds(groupBounds);
     }
 
     /**
@@ -420,22 +421,26 @@ class RaphaelBulletChart {
      * @returns {Array.<object>} - color and opacity of series
      */
     getGraphColors() {
-        return this.groupBars.map((barSet, groupIndex) => {
-            const barColors = [];
-            const markerCount = this.groupLines[groupIndex].length;
+        if (!this._graphColors.length) {
+            this._graphColors = this.groupBars.map((barSet, groupIndex) => {
+                const barColors = [];
+                const markerCount = this.groupLines[groupIndex].length;
 
-            barSet.forEach(item => {
-                barColors.push(item.attrs.fill);
+                barSet.forEach(item => {
+                    barColors.push(item.attrs.fill);
+                });
+
+                const legendColor = barColors[barColors.length - 1];
+
+                for (let i = 0; i <= markerCount; i += 1) {
+                    barColors.push(legendColor);
+                }
+
+                return barColors;
             });
+        }
 
-            const legendColor = barColors[barColors.length - 1];
-
-            for (let i = 0; i <= markerCount; i += 1) {
-                barColors.push(legendColor);
-            }
-
-            return barColors;
-        });
+        return this._graphColors;
     }
 }
 

--- a/src/js/plugins/raphaelBulletChart.js
+++ b/src/js/plugins/raphaelBulletChart.js
@@ -301,10 +301,16 @@ class RaphaelBulletChart {
      */
     resizeClipRect(width, height) {
         const clipRect = this.paper.getById(`${this._getClipRectId()}_rect`);
-        clipRect.attr({
-            width,
-            height
-        });
+
+        // Animation was implemented using <clipPath> SVG element
+        // As Browser compatibility of <clipPath> is IE9+,
+        // No Animation on IE8
+        if (clipRect) {
+            clipRect.attr({
+                width,
+                height
+            });
+        }
     }
 
     /**

--- a/src/js/plugins/raphaelPieChart.js
+++ b/src/js/plugins/raphaelPieChart.js
@@ -413,27 +413,8 @@ class RaphaelPieChart {
      */
     resize(params) {
         const {dimension, circleBound} = params;
-        const {sectorName, labelSet} = this;
-
         this.circleBound = circleBound;
         this.paper.setSize(dimension.width, dimension.height);
-
-        this.sectorInfos.forEach((sectorInfo, index) => {
-            const {angles} = sectorInfo;
-            const attrs = {};
-
-            attrs[sectorName] = [circleBound.cx, circleBound.cy, circleBound.r, angles.startAngle, angles.endAngle];
-            sectorInfo.sector.attr(attrs);
-
-            if (labelSet && labelSet.length) {
-                const bBox = sectorInfo.sector.getBBox();
-
-                labelSet[index].attr({
-                    x: bBox.x + (bBox.width / 2),
-                    y: bBox.y + (bBox.height / 2)
-                });
-            }
-        });
     }
 
     findSectorInfo(position) {


### PR DESCRIPTION
## work
- 블릿차트의 경우 차트 리사이즈후 render 메서드를 불필요하게 2번 호출하는 문제를 수정
   (resize() 메서드에서 _renderBounds메서드를 제거 )
- getGraphColors() 메서드에서 resize에 의한 render 의 경우에는 캐싱된 결과 값을 반환하도록 수정

## demo
- http://10.78.9.21:8083/examples/example15-02-bullet-chart-resizetest.html