### PR TITLE
Fix/piechart export

### DIFF
--- a/src/js/helpers/dataExporter.js
+++ b/src/js/helpers/dataExporter.js
@@ -30,6 +30,8 @@ const dataExporter = {
     downloadData(fileName, extension, rawData, downloadOption) {
         const chartData2DArray = _get2DArrayFromRawData(rawData);
         const contentType = DATA_URI_HEADERS[extension].replace(/(data:|;base64,|,%EF%BB%BF)/g, '');
+        // console.log('RAWDATA', rawData);
+        // console.log('CHARTDATA2DARRAY', chartData2DArray);
         let content = DATA_URI_BODY_MAKERS[extension](chartData2DArray, downloadOption);
 
         if (this._isNeedDataEncodeing()) {
@@ -98,7 +100,9 @@ function _get2DArrayFromRawData(rawData) {
 
         Object.values((rawData.series || {})).forEach(seriesDatum => {
             seriesDatum.forEach(seriesItem => {
-                resultArray.push([seriesItem.name, ...seriesItem.data]);
+                const data = (typeof seriesItem.data === 'object') ? seriesItem.data : [seriesItem.data];
+
+                resultArray.push([seriesItem.name, ...data]);
             });
         });
     }

--- a/src/js/helpers/dataExporter.js
+++ b/src/js/helpers/dataExporter.js
@@ -98,7 +98,7 @@ function _get2DArrayFromRawData(rawData) {
 
         Object.values((rawData.series || {})).forEach(seriesDatum => {
             seriesDatum.forEach(seriesItem => {
-                const data = (typeof seriesItem.data === 'object') ? seriesItem.data : [seriesItem.data];
+                const data = (snippet.isArray(seriesItem.data)) ? seriesItem.data : [seriesItem.data];
 
                 resultArray.push([seriesItem.name, ...data]);
             });

--- a/src/js/helpers/dataExporter.js
+++ b/src/js/helpers/dataExporter.js
@@ -30,8 +30,6 @@ const dataExporter = {
     downloadData(fileName, extension, rawData, downloadOption) {
         const chartData2DArray = _get2DArrayFromRawData(rawData);
         const contentType = DATA_URI_HEADERS[extension].replace(/(data:|;base64,|,%EF%BB%BF)/g, '');
-        // console.log('RAWDATA', rawData);
-        // console.log('CHARTDATA2DARRAY', chartData2DArray);
         let content = DATA_URI_BODY_MAKERS[extension](chartData2DArray, downloadOption);
 
         if (this._isNeedDataEncodeing()) {

--- a/test/helpers/dataExporter.spec.js
+++ b/test/helpers/dataExporter.spec.js
@@ -98,8 +98,8 @@ describe('Test for dataExporter', () => {
     });
 
     describe('_get2DArrayFromRawData()', () => {
-        const result = [['', 'jan', 'feb'], ['john', 10, 20], ['jane', 30, 25]];
         it('should create 2D array from rawData.', () => {
+            const result = [['', 'jan', 'feb'], ['john', 10, 20], ['jane', 30, 25]];
             expect(dataExporter._get2DArrayFromRawData({
                 categories: ['jan', 'feb'],
                 series: {
@@ -109,6 +109,22 @@ describe('Test for dataExporter', () => {
                     }, {
                         name: 'jane',
                         data: [30, 25]
+                    }]
+                }
+            })).toEqual(result);
+        });
+
+        it('even if the data is not an array, it must be a normal concat.', () => {
+            const result = [['', 'jan', 'feb'], ['john', 10], ['jane', 30]];
+            expect(dataExporter._get2DArrayFromRawData({
+                categories: ['jan', 'feb'],
+                series: {
+                    line: [{
+                        name: 'john',
+                        data: 10
+                    }, {
+                        name: 'jane',
+                        data: 30
                     }]
                 }
             })).toEqual(result);


### PR DESCRIPTION
## work
- pie차트에서 data export시 내용이 비어 나오는 버그 수정.
-  배열 concat을 위해 spread array를 사용하였지만, pie차트는 data가 array가 아님으로 정상동작 하지 않는 부분을 해결해줌