### PR TITLE
fix: Invalid calculation of series area

### DIFF
--- a/src/js/models/bounds/seriesCalculator.js
+++ b/src/js/models/bounds/seriesCalculator.js
@@ -56,23 +56,13 @@ export default {
      */
     calculateHeight(dimensionMap, legendOptions, yAxisTitleAreaHeight) {
         const chartHeight = dimensionMap.chart.height;
-        const titleHeight = dimensionMap.title.height;
-        const hasTitle = titleHeight > 0;
-        const chartExportMenuHeight = dimensionMap.chartExportMenu.height;
+        const titleHeight = Math.max(dimensionMap.title.height, dimensionMap.chartExportMenu.height);
         const legendHeight = legendOptions.visible ? dimensionMap.legend.height : 0;
         const topLegendHeight = predicate.isLegendAlignTop(legendOptions.align) ? legendHeight : 0;
-        const topAreaExceptTitleHeight = Math.max(yAxisTitleAreaHeight, topLegendHeight);
-
-        let topAreaHeight = Math.max(dimensionMap.title.height, chartExportMenuHeight);
-        let bottomAreaHeight = dimensionMap.xAxis.height;
-
-        if (hasTitle) {
-            topAreaHeight = titleHeight + Math.max(0, topAreaExceptTitleHeight - chartConst.TITLE_PADDING);
-        } else {
-            topAreaHeight = Math.max(chartExportMenuHeight, topAreaExceptTitleHeight);
-        }
-
-        bottomAreaHeight += (predicate.isLegendAlignBottom(legendOptions.align) ? legendHeight : 0);
+        const topAreaPadding = Math.max(0, Math.max(yAxisTitleAreaHeight, topLegendHeight) - chartConst.TITLE_PADDING);
+        const topAreaHeight = titleHeight + topAreaPadding;
+        const bottomLegendHeight = predicate.isLegendAlignBottom(legendOptions.align) ? legendHeight : 0;
+        const bottomAreaHeight = dimensionMap.xAxis.height + bottomLegendHeight;
 
         return chartHeight - (chartConst.CHART_PADDING * 2) - topAreaHeight - bottomAreaHeight;
     }

--- a/test/models/bounds/seriesCalculator.spec.js
+++ b/test/models/bounds/seriesCalculator.spec.js
@@ -202,6 +202,34 @@ describe('Test for seriesCalculator', () => {
             expect(actual).toBe(250);
         });
 
+        it('calculate height, when align option is top and text is empty', () => {
+            const dimensionMap = {
+                chart: {
+                    height: 400
+                },
+                title: {
+                    height: 0
+                },
+                legend: {
+                    height: 50
+                },
+                xAxis: {
+                    height: 50
+                },
+                chartExportMenu: {
+                    height: 30
+                }
+            };
+            const legendOption = {
+                align: chartConst.LEGEND_ALIGN_TOP,
+                visible: true
+            };
+            const yAxisTitleAreaHeight = 20;
+            const actual = seriesCalculator.calculateHeight(dimensionMap, legendOption, yAxisTitleAreaHeight);
+
+            expect(actual).toBe(270);
+        });
+
         it('calculate height, when align option is bottom', () => {
             const dimensionMap = {
                 chart: {


### PR DESCRIPTION
## work
- legend.align 옵션이 'top'이고 chart.title 의 값이 빈 값일때 차트 영역의 끝인 x축 레이블이 잘려보임
- calculateHeight() 메서드에서 시리즈 영역의 높이 계산식을 serise영역의 positionTop 계산식과 비교하여 정확히 맞추어줌
![image](https://user-images.githubusercontent.com/35218826/42934000-1c7c598a-8b81-11e8-93fe-2ebd40d5b304.png)


## demo
- http://10.78.9.21:8083/examples/example03-01-line-chart-basic.html