### PR TITLE
fix: image export zero size bug in line-chart

### DIFF
--- a/src/js/components/chartExportMenu/chartExportMenu.js
+++ b/src/js/components/chartExportMenu/chartExportMenu.js
@@ -274,10 +274,11 @@ class ChartExportMenu {
      */
     _onClick(e) {
         const elTarget = e.target || e.srcElement;
-        const [svgElement] = this.container.parentNode.getElementsByTagName('svg');
 
         if (dom.hasClass(elTarget, CLASS_NAME_CHART_EXPORT_MENU_ITEM)) {
             if (elTarget.id) {
+                const svgElement = this._getMainSvgElemenmt(this.container.parentNode);
+
                 this.eventBus.fire('beforeImageDownload');
 
                 chartExporter.exportChart(this.exportFilename, elTarget.id,
@@ -294,6 +295,25 @@ class ChartExportMenu {
         } else {
             this._hideChartExportMenu();
         }
+    }
+
+    /**
+     * Return chart svg
+     * @param {HTMLElement} mainContainer - chart container element
+     * @returns {HTMLElement} - chart main svg element
+     * @private
+     */
+    _getMainSvgElemenmt(mainContainer) {
+        const svgElements = Array.from(mainContainer.getElementsByTagName('svg'));
+        let svgElement;
+
+        svgElements.forEach(svg => {
+            if (mainContainer === svg.parentNode) {
+                svgElement = svg;
+            }
+        });
+
+        return svgElement;
     }
 
     /**

--- a/test/components/chartExportMenu/chartExportMenu.spec.js
+++ b/test/components/chartExportMenu/chartExportMenu.spec.js
@@ -17,4 +17,25 @@ describe('chartExportMenu', () => {
         });
         expect(chartExportMenu.exportFilename).toBe('custom_file_name');
     });
+
+    it('_getMainSvgElemenmt() must find svg that exists under 1level of mainContainer.', () => {
+        const chartExportMenu = new ChartExportMenu({
+            options: {visible: true},
+            chartOptions: {
+                chartExportMenu: {
+                    filename: 'custom_file_name'
+                }
+            }
+        });
+        const mainContainer = document.createElement('div');
+        const subContainer = document.createElement('div');
+        const mainSvg = document.createElement('svg');
+        const toolbarSvg = document.createElement('svg');
+
+        subContainer.appendChild(toolbarSvg);
+        mainContainer.appendChild(subContainer);
+        mainContainer.appendChild(mainSvg);
+
+        expect(chartExportMenu._getMainSvgElemenmt(mainContainer)).toBe(mainSvg);
+    });
 });


### PR DESCRIPTION
## work
- 라인차트에서 series영역에 마우스 오버 후 툴팁 image 내보내기시 0바이트의 이미지가 생성되는 버그
- tooltip 내 라인 아이콘을 svg로 그렸기 때문에 container내의 svg selector가 잘못된 svg를 select하는 이슈가 있었음. (컨테이너 바로 1level 아래 있는 chart의 svg를 정확히 select하는 메소드를 만들어서 사용하도록 수정) 