### PR TITLE
fixed pie chart zero raow data and showlabel

### DIFF
--- a/src/js/components/series/pieChartSeries.js
+++ b/src/js/components/series/pieChartSeries.js
@@ -557,8 +557,8 @@ class PieChartSeries extends Series {
         ).height;
 
         return (this.seriesData.sectorData || []).map(datum => {
-            const position = datum.ratio ? Object.assign({}, datum[positionType]) : {};
-            const isReCalculatePosition = datum.ratio && showLegend && showLabel && !this.isLabelAlignOuter;
+            const position = datum.ratio ? Object.assign({}, datum[positionType]) : null;
+            const isReCalculatePosition = position && showLegend && showLabel && !this.isLabelAlignOuter;
 
             if (isReCalculatePosition) {
                 if (dataType === 'value') {

--- a/src/js/components/series/pieChartSeries.js
+++ b/src/js/components/series/pieChartSeries.js
@@ -558,8 +558,9 @@ class PieChartSeries extends Series {
 
         return (this.seriesData.sectorData || []).map(datum => {
             const position = datum.ratio ? Object.assign({}, datum[positionType]) : {};
+            const isReCalculatePosition = datum.ratio && showLegend && showLabel && !this.isLabelAlignOuter;
 
-            if (showLegend && showLabel && !this.isLabelAlignOuter) {
+            if (isReCalculatePosition) {
                 if (dataType === 'value') {
                     position.top -= valueLabelHeight / 2;
                 } else if (dataType === 'legend') {

--- a/src/js/components/series/pieChartSeries.js
+++ b/src/js/components/series/pieChartSeries.js
@@ -557,7 +557,7 @@ class PieChartSeries extends Series {
         ).height;
 
         return (this.seriesData.sectorData || []).map(datum => {
-            const position = datum.ratio ? Object.assign({}, datum[positionType]) : null;
+            const position = datum.ratio ? Object.assign({}, datum[positionType]) : {};
 
             if (showLegend && showLabel && !this.isLabelAlignOuter) {
                 if (dataType === 'value') {

--- a/test/components/series/pieChartSeries.spec.js
+++ b/test/components/series/pieChartSeries.spec.js
@@ -569,7 +569,7 @@ describe('PieChartSeries', () => {
         });
     });
     describe('_pickPositionsFromSectorData()', () => {
-        it('Should return Object even if the ratio value is zero.', () => {
+        it('Should return null even if the ratio value is zero.', () => {
             series.options = {
                 showLabel: true,
                 showLegend: true
@@ -586,7 +586,7 @@ describe('PieChartSeries', () => {
 
             const result = series._pickPositionsFromSectorData('centerPosition', 'value');
 
-            expect(result[0]).toEqual({});
+            expect(result[0]).toBe(null);
         });
     });
 

--- a/test/components/series/pieChartSeries.spec.js
+++ b/test/components/series/pieChartSeries.spec.js
@@ -570,6 +570,10 @@ describe('PieChartSeries', () => {
     });
     describe('_pickPositionsFromSectorData()', () => {
         it('Should return Object even if the ratio value is zero.', () => {
+            series.options = {
+                showLabel: true,
+                showLegend: true
+            };
             series.seriesData = {
                 sectorData: [{
                     ratio: 0,

--- a/test/components/series/pieChartSeries.spec.js
+++ b/test/components/series/pieChartSeries.spec.js
@@ -568,6 +568,23 @@ describe('PieChartSeries', () => {
             expect(positions[2].end.left).toBe(80);
         });
     });
+    describe('_pickPositionsFromSectorData()', () => {
+        it('Should return Object even if the ratio value is zero.', () => {
+            series.seriesData = {
+                sectorData: [{
+                    ratio: 0,
+                    centerPosition: {left: 463.44849855259173, top: 287.3915761608463}
+                }, {
+                    ratio: 10,
+                    centerPosition: {left: 404.3042587679865, top: 501.44603132368695}
+                }]
+            };
+
+            const result = series._pickPositionsFromSectorData('centerPosition', 'value');
+
+            expect(result[0]).toEqual({});
+        });
+    });
 
     describe('_renderSeriesLabel()', () => {
         let seriesDataModel, paper;


### PR DESCRIPTION
## work
- 파이 차트에서 값이 0인 데이터가 있고 showLabel, showLegend값이 모두 true일때 값이 0이면  레이블 포지션을 다시 계산할 필요가 없으로 계산하지 않도록 if문 안에 조건식을 엄격하게 변경 
- 관련된 테스트 추가