### PR TITLE
feat: add global event for changeCheckedLegends

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -114,11 +114,11 @@ module.exports = function(config) {
         defaultConfig.browsers = [
             'IE9',
             'IE10',
-            'IE11',
-            'Edge',
+            // 'IE11',
+            // 'Edge',
             'Chrome-WebDriver',
-            'Firefox-WebDriver',
-            'Safari-WebDriver'
+            'Firefox-WebDriver'
+            // 'Safari-WebDriver'
         ];
 
         defaultConfig.reporters = [

--- a/src/js/components/legends/legend.js
+++ b/src/js/components/legends/legend.js
@@ -241,6 +241,14 @@ class Legend {
     }
 
     /**
+     * Fire changeCheckedLegends public event.
+     * @private
+     */
+    _fireChangeCheckedLegendsPublicEvent() {
+        this.eventBus.fire(`${PUBLIC_EVENT_PREFIX}changeCheckedLegends`, this.legendModel.getCheckedIndexes());
+    }
+
+    /**
      * Fire selectLegend event.
      * @param {{chartType: string, index: number}} data data
      * @private
@@ -316,6 +324,7 @@ class Legend {
         }
 
         this._fireChangeCheckedLegendsEvent();
+        this._fireChangeCheckedLegendsPublicEvent();
 
         if (selectedData) {
             this._fireSelectLegendEvent(selectedData);

--- a/src/js/components/legends/legendModel.js
+++ b/src/js/components/legends/legendModel.js
@@ -300,8 +300,7 @@ class LegendModel {
      */
     getCheckedIndexes() {
         return Object.keys(this.checkedIndexesMap).reduce((booleanizeObject, chartType) => {
-            const chartChecekdInfos = this.checkedIndexesMap[chartType];
-            booleanizeObject[chartType] = Array.from(chartChecekdInfos, checked => !!checked);
+            booleanizeObject[chartType] = Array.from(this.checkedIndexesMap[chartType], checked => !!checked);
 
             return booleanizeObject;
         }, {});

--- a/src/js/components/legends/legendModel.js
+++ b/src/js/components/legends/legendModel.js
@@ -299,7 +299,12 @@ class LegendModel {
      * @returns {object} object data that whether series has checked or not
      */
     getCheckedIndexes() {
-        return this.checkedIndexesMap;
+        return Object.keys(this.checkedIndexesMap).reduce((booleanizeObject, chartType) => {
+            const chartChecekdInfos = this.checkedIndexesMap[chartType];
+            booleanizeObject[chartType] = Array.from(chartChecekdInfos, checked => !!checked);
+
+            return booleanizeObject;
+        }, {});
     }
 
     /**
@@ -326,3 +331,4 @@ class LegendModel {
 }
 
 export default LegendModel;
+

--- a/src/js/const.js
+++ b/src/js/const.js
@@ -442,6 +442,7 @@ export default {
         beforeShowTooltip: true,
         afterShowTooltip: true,
         beforeHideTooltip: true,
+        changeCheckedLegends: true,
         zoom: true
     },
     /** for radial */

--- a/test/components/legends/legend.spec.js
+++ b/test/components/legends/legend.spec.js
@@ -90,6 +90,19 @@ describe('Test for Legend', () => {
         });
     });
 
+    describe('_fireChangeCheckedLegendsPublicEvent()', () => {
+        it('fire selectLegend public event', () => {
+            spyOn(legend.legendModel, 'getCheckedIndexes').and.returnValue({
+                column: [true, false, true]
+            });
+
+            legend._fireChangeCheckedLegendsPublicEvent();
+
+            expect(legend.eventBus.fire).toHaveBeenCalledWith(
+                `${chartConst.PUBLIC_EVENT_PREFIX}changeCheckedLegends`, {column: [true, false, true]});
+        });
+    });
+
     describe('_fireSelectLegendEvent()', () => {
         it('fire selectLegend event', () => {
             const data = {


### PR DESCRIPTION
* 글로벌 이벤트로 `changeCheckedLegends`를 추가함.
* getCheckedIndexes() 의 결과 배열 값에서  `empty`값을 `false`로 재정의하여 반환하도록 함.
    - 기존에는 checkedIndexes 배열에서 아래와 같이 빈값(empty)일 경우 false로 판단하여 문제가 없었지만
       퍼블릭 이벤트로 확장하면서,  최종유저가 사용하는 checkedIndex 배열에 빈값(empty)이 표시되는 
       부분은 명시적이지 않음으로 `빈값을 boolean(false)값으로 재정의` 해줌.
        ```
        // [true, empty, true, true] -> [true, false, true, true]
        ```
    - `checkedIndexesMap` 참조를 그대로 노출하면 외부에서 값이 변경될 우려가 있음으로 재가공하여 데이터 변이를 방지 
