### PR TITLE
Fix/chart format option withtooltip

### DIFF
--- a/examples/example02-01-column-chart-basic.html
+++ b/examples/example02-01-column-chart-basic.html
@@ -42,18 +42,6 @@ var data = {
         {
             name: 'Budget',
             data: [5000, 3000, 5000, 7000, 6000, 4000, 1000]
-        },
-        {
-            name: 'Income',
-            data: [8000, 1000, 7000, 2000, 6000, 3000, 5000]
-        },
-        {
-            name: 'Expenses',
-            data: [4000, 4000, 6000, 3000, 4000, 5000, 7000]
-        },
-        {
-            name: 'Debt',
-            data: [6000, 3000, 3000, 1000, 2000, 4000, 3000]
         }
     ]
 };
@@ -74,6 +62,9 @@ var options = {
     },
     legend: {
         align: 'top'
+    },
+    series: {
+      colorByPoint: true
     }
 };
 var theme = {

--- a/examples/example02-01-column-chart-basic.html
+++ b/examples/example02-01-column-chart-basic.html
@@ -42,6 +42,18 @@ var data = {
         {
             name: 'Budget',
             data: [5000, 3000, 5000, 7000, 6000, 4000, 1000]
+        },
+        {
+            name: 'Income',
+            data: [8000, 1000, 7000, 2000, 6000, 3000, 5000]
+        },
+        {
+            name: 'Expenses',
+            data: [4000, 4000, 6000, 3000, 4000, 5000, 7000]
+        },
+        {
+            name: 'Debt',
+            data: [6000, 3000, 3000, 1000, 2000, 4000, 3000]
         }
     ]
 };
@@ -62,9 +74,6 @@ var options = {
     },
     legend: {
         align: 'top'
-    },
-    series: {
-      colorByPoint: true
     }
 };
 var theme = {
@@ -75,12 +84,9 @@ var theme = {
         ]
     }
 };
-
 // For apply theme
-
 // tui.chart.registerTheme('myTheme', theme);
 // options.theme = 'myTheme';
-
 tui.chart.columnChart(container, data, options);
 </script>
 

--- a/examples/example03-01-line-chart-basic.html
+++ b/examples/example03-01-line-chart-basic.html
@@ -68,7 +68,18 @@ var options = {
     chart: {
         width: 1160,
         height: 540,
-        title: '24-hr Average Temperature'
+        title: '24-hr Average Temperature',
+        format: function(value, chartType, areaType, valuetype, legendName) {
+            console.log(chartType, areaType, valuetype);
+            if (areaType === 'makingSeriesLabel' && value == 25.2) {
+                return 'min: ' + value;
+                
+            } else if(areaType === 'makingSeriesLabel') {
+                return '';
+            } else {
+                return value;
+            }
+        }
     },
     yAxis: {
         title: 'Temperature (Celsius)',
@@ -81,7 +92,8 @@ var options = {
     },
     series: {
         showDot: false,
-        zoomable: true
+        zoomable: true,
+        showLabel: true
     },
     tooltip: {
         suffix: '°C'

--- a/examples/example03-01-line-chart-basic.html
+++ b/examples/example03-01-line-chart-basic.html
@@ -68,18 +68,7 @@ var options = {
     chart: {
         width: 1160,
         height: 540,
-        title: '24-hr Average Temperature',
-        format: function(value, chartType, areaType, valuetype, legendName) {
-            console.log(chartType, areaType, valuetype);
-            if (areaType === 'makingSeriesLabel' && value == 25.2) {
-                return 'min: ' + value;
-                
-            } else if(areaType === 'makingSeriesLabel') {
-                return '';
-            } else {
-                return value;
-            }
-        }
+        title: '24-hr Average Temperature'
     },
     yAxis: {
         title: 'Temperature (Celsius)',
@@ -92,8 +81,7 @@ var options = {
     },
     series: {
         showDot: false,
-        zoomable: true,
-        showLabel: true
+        zoomable: true
     },
     tooltip: {
         suffix: '°C'
@@ -107,12 +95,9 @@ var theme = {
         ]
     }
 };
-
 // For apply theme
-
 // tui.chart.registerTheme('myTheme', theme);
 // options.theme = 'myTheme';
-
 var chart = tui.chart.lineChart(container, data, options);
 </script>
 <!--For tutorial page-->

--- a/examples/example08-01-combo-chart-column-and-line.html
+++ b/examples/example08-01-combo-chart-column-and-line.html
@@ -38,7 +38,6 @@
 <script type='text/javascript' src='https://rawgit.com/nhnent/raphael/v2.2.0b/raphael.js'></script>
 <script src='../dist/tui-chart.js'></script>
 <script class='code-js' id='code-js'>
-/* min, max를 구하는 함수 */
 var container = document.getElementById('chart-area');
 var data = {
     categories: ['Apr', 'May', 'June', 'July', 'Aug', 'Sep', 'Oct'],
@@ -51,9 +50,7 @@ var data = {
             {
                 name: 'NewYork',
                 data: [9.9, 16.0, 21.2, 24.2, 23.2, 19.4, 13.3]
-
             },
-
             {
                 name: 'Sydney',
                 data: [18.3, 15.2, 12.8, 11.8, 13.0, 15.2, 17.6]
@@ -71,23 +68,11 @@ var data = {
         ]
     }
 };
-
 var options = {
     chart: {
         width: 1160,
         height: 540,
-        title: '24-hr Average Temperature',
-        format: function(value, chartType, areaType, valuetype, legendName) {
-            // console.log(value, chartType, areaType, valuetype, legendName);
-            if (areaType === 'makingSeriesLabel' && value == 19.7) {
-                return 'min: ' + value;
-                
-            } else if(areaType === 'makingSeriesLabel') {
-                return '';
-            } else {
-                return value;
-            }
-        }
+        title: '24-hr Average Temperature'
     },
     yAxis: [{
        title: 'Temperature (Celsius)',
@@ -103,11 +88,7 @@ var options = {
     }],
     series: {
         line: {
-            showDot: true,
-            showLabel: true
-        },
-        column: {
-            showLabel: true
+            showDot: true
         }
     },
     tooltip: {
@@ -127,12 +108,9 @@ var theme = {
         }
     }
 };
-
 // For apply theme
-
 // tui.chart.registerTheme('myTheme', theme);
 // options.theme = 'myTheme';
-
 var chart = tui.chart.comboChart(container, data, options);
 </script>
 <!--For tutorial page-->

--- a/examples/example08-01-combo-chart-column-and-line.html
+++ b/examples/example08-01-combo-chart-column-and-line.html
@@ -38,6 +38,7 @@
 <script type='text/javascript' src='https://rawgit.com/nhnent/raphael/v2.2.0b/raphael.js'></script>
 <script src='../dist/tui-chart.js'></script>
 <script class='code-js' id='code-js'>
+/* min, max를 구하는 함수 */
 var container = document.getElementById('chart-area');
 var data = {
     categories: ['Apr', 'May', 'June', 'July', 'Aug', 'Sep', 'Oct'],
@@ -70,11 +71,23 @@ var data = {
         ]
     }
 };
+
 var options = {
     chart: {
         width: 1160,
         height: 540,
-        title: '24-hr Average Temperature'
+        title: '24-hr Average Temperature',
+        format: function(value, chartType, areaType, valuetype, legendName) {
+            // console.log(value, chartType, areaType, valuetype, legendName);
+            if (areaType === 'makingSeriesLabel' && value == 19.7) {
+                return 'min: ' + value;
+                
+            } else if(areaType === 'makingSeriesLabel') {
+                return '';
+            } else {
+                return value;
+            }
+        }
     },
     yAxis: [{
        title: 'Temperature (Celsius)',
@@ -90,7 +103,11 @@ var options = {
     }],
     series: {
         line: {
-            showDot: true
+            showDot: true,
+            showLabel: true
+        },
+        column: {
+            showLabel: true
         }
     },
     tooltip: {

--- a/src/js/components/tooltips/groupTooltip.js
+++ b/src/js/components/tooltips/groupTooltip.js
@@ -180,7 +180,7 @@ class GroupTooltip extends TooltipBase {
         return this.dataProcessor.getSeriesGroups().map((seriesGroup, index) => {
             const values = seriesGroup.map(item => ({
                 type: item.type || 'data',
-                label: item.label
+                label: item.tooltipLabel || item.label
             }));
 
             return {

--- a/src/js/components/tooltips/normalTooltip.js
+++ b/src/js/components/tooltips/normalTooltip.js
@@ -42,8 +42,6 @@ class NormalTooltip extends TooltipBase {
     _makeTooltipHtml(category, item) {
         const template = this._getTooltipTemplate(item);
 
-        console.log('MMMMMMMMMMMM', item);
-
         return template(snippet.extend({
             categoryVisible: category ? 'show' : 'hide',
             category

--- a/src/js/components/tooltips/normalTooltip.js
+++ b/src/js/components/tooltips/normalTooltip.js
@@ -41,6 +41,9 @@ class NormalTooltip extends TooltipBase {
      */
     _makeTooltipHtml(category, item) {
         const template = this._getTooltipTemplate(item);
+
+        console.log('MMMMMMMMMMMM', item);
+
         return template(snippet.extend({
             categoryVisible: category ? 'show' : 'hide',
             category

--- a/src/js/helpers/renderUtil.js
+++ b/src/js/helpers/renderUtil.js
@@ -399,6 +399,10 @@ const renderUtil = {
             chartType
         } = params;
         const fns = [String(value), ...formatFunctions || []];
+
+        // console.log("PARAMS - ", params);
+        // console.log("FORMATFUNCTIONS - ", formatFunctions);
+
         // const fns = [String(value)];
 
         return snippet.reduce(fns, (stored, fn) => fn(stored, chartType, areaType, valueType, legendName));

--- a/src/js/helpers/renderUtil.js
+++ b/src/js/helpers/renderUtil.js
@@ -400,11 +400,6 @@ const renderUtil = {
         } = params;
         const fns = [String(value), ...formatFunctions || []];
 
-        // console.log("PARAMS - ", params);
-        // console.log("FORMATFUNCTIONS - ", formatFunctions);
-
-        // const fns = [String(value)];
-
         return snippet.reduce(fns, (stored, fn) => fn(stored, chartType, areaType, valueType, legendName));
     },
     /**

--- a/src/js/models/data/seriesItem.js
+++ b/src/js/models/data/seriesItem.js
@@ -157,15 +157,14 @@ class SeriesItem {
         }
 
         if (snippet.isNull(value)) {
-            this.label = '';
-            this.tooltipLabel = '';
+            this._setLabel('');
         } else {
-            ['label', 'tooltipLabel'].forEach(propName => {
-                this[propName] = renderUtil.formatValue({
+            ['label', 'tooltipLabel'].forEach(labelType => {
+                this[labelType] = renderUtil.formatValue({
                     value,
                     formatFunctions: this.formatFunctions,
                     chartType: this.chartType,
-                    areaType: propName === 'tooltipLabel' ? 'makingTooltipLabel' : 'makingSeriesLabel',
+                    areaType: labelType === 'tooltipLabel' ? 'makingTooltipLabel' : 'makingSeriesLabel',
                     legendName: this.legendName
                 });
             });
@@ -178,6 +177,16 @@ class SeriesItem {
             this._updateFormattedValueforRange();
             this.isRange = true;
         }
+    }
+
+    /**
+     * set label property
+     * @param {string} value set value
+     * @private
+     */
+    _setLabel(value) {
+        this.label = value;
+        this.tooltipLabel = value;
     }
 
     /**
@@ -225,8 +234,7 @@ class SeriesItem {
      * @private
      */
     _updateFormattedValueforRange() {
-        this.label = `${this.startLabel} ~ ${this.endLabel}`;
-        this.tooltipLabel = `${this.startLabel} ~ ${this.endLabel}`;
+        this._setLabel(`${this.startLabel} ~ ${this.endLabel}`);
     }
 
     /**

--- a/src/js/models/data/seriesItem.js
+++ b/src/js/models/data/seriesItem.js
@@ -146,7 +146,6 @@ class SeriesItem {
      */
     _initValues(rawValue, index) {
         const values = this._createValues(rawValue);
-        const areaType = 'makingSeriesLabel';
         const hasStart = values.length > 1;
         let [value] = values;
 
@@ -157,29 +156,19 @@ class SeriesItem {
             value = Math.abs(value);
         }
 
-        console.log('MAKE INIT VALUE');
-
         if (snippet.isNull(value)) {
             this.label = '';
             this.tooltipLabel = '';
         } else {
-            this.label = renderUtil.formatValue({
-                value,
-                formatFunctions: this.formatFunctions,
-                chartType: this.chartType,
-                areaType,
-                legendName: this.legendName
+            ['label', 'tooltipLabel'].forEach(propName => {
+                this[propName] = renderUtil.formatValue({
+                    value,
+                    formatFunctions: this.formatFunctions,
+                    chartType: this.chartType,
+                    areaType: propName === 'tooltipLabel' ? 'makingTooltipLabel' : 'makingSeriesLabel',
+                    legendName: this.legendName
+                });
             });
-
-            /*
-            this.tooltipLabel = renderUtil.formatValue({
-                value,
-                formatFunctions: this.formatFunctions,
-                chartType: this.chartType,
-                areaType: 'makingTooltipLabel',
-                legendName: this.legendName
-            });
-            */
         }
 
         this.endLabel = this.label;
@@ -237,6 +226,7 @@ class SeriesItem {
      */
     _updateFormattedValueforRange() {
         this.label = `${this.startLabel} ~ ${this.endLabel}`;
+        this.tooltipLabel = `${this.startLabel} ~ ${this.endLabel}`;
     }
 
     /**

--- a/src/js/models/data/seriesItem.js
+++ b/src/js/models/data/seriesItem.js
@@ -68,6 +68,12 @@ class SeriesItem {
         this.label = null;
 
         /**
+         * tooltip label
+         * @type {string}
+         */
+        this.tooltipLabel = null;
+
+        /**
          * ratio of value about distance of limit
          * @type {number}
          */
@@ -151,8 +157,11 @@ class SeriesItem {
             value = Math.abs(value);
         }
 
+        console.log('MAKE INIT VALUE');
+
         if (snippet.isNull(value)) {
             this.label = '';
+            this.tooltipLabel = '';
         } else {
             this.label = renderUtil.formatValue({
                 value,
@@ -161,6 +170,16 @@ class SeriesItem {
                 areaType,
                 legendName: this.legendName
             });
+
+            /*
+            this.tooltipLabel = renderUtil.formatValue({
+                value,
+                formatFunctions: this.formatFunctions,
+                chartType: this.chartType,
+                areaType: 'makingTooltipLabel',
+                legendName: this.legendName
+            });
+            */
         }
 
         this.endLabel = this.label;

--- a/src/js/themes/themeManager.js
+++ b/src/js/themes/themeManager.js
@@ -182,12 +182,28 @@ export default {
         let seriesCount = 0;
 
         if (rawSeriesDatum && rawSeriesDatum.length) {
+            /*
             if (rawSeriesDatum.colorLength) {
                 seriesCount = rawSeriesDatum.colorLength;
             } else {
                 seriesCount = rawSeriesDatum.length;
             }
+            */
+
+            console.log('RAWSERIESDATUM - ', rawSeriesDatum);
+            if (rawSeriesDatum.colorLength) {
+                console.log('a');
+                seriesCount = rawSeriesDatum.colorLength;
+            } else if (rawSeriesDatum[0] && rawSeriesDatum[0].data && rawSeriesDatum[0].data.length) {
+                console.log('b');
+                seriesCount = Math.max(rawSeriesDatum.length, rawSeriesDatum[0].data.length);
+            } else {
+                console.log('c');
+                seriesCount = rawSeriesDatum.length;
+            }
         }
+
+        console.log("SERIESCOUNT", seriesCount);
 
         return seriesCount;
     },

--- a/src/js/themes/themeManager.js
+++ b/src/js/themes/themeManager.js
@@ -182,28 +182,12 @@ export default {
         let seriesCount = 0;
 
         if (rawSeriesDatum && rawSeriesDatum.length) {
-            /*
             if (rawSeriesDatum.colorLength) {
                 seriesCount = rawSeriesDatum.colorLength;
             } else {
-                seriesCount = rawSeriesDatum.length;
-            }
-            */
-
-            console.log('RAWSERIESDATUM - ', rawSeriesDatum);
-            if (rawSeriesDatum.colorLength) {
-                console.log('a');
-                seriesCount = rawSeriesDatum.colorLength;
-            } else if (rawSeriesDatum[0] && rawSeriesDatum[0].data && rawSeriesDatum[0].data.length) {
-                console.log('b');
-                seriesCount = Math.max(rawSeriesDatum.length, rawSeriesDatum[0].data.length);
-            } else {
-                console.log('c');
                 seriesCount = rawSeriesDatum.length;
             }
         }
-
-        console.log("SERIESCOUNT", seriesCount);
 
         return seriesCount;
     },

--- a/test/models/data/seriesItem.spec.js
+++ b/test/models/data/seriesItem.spec.js
@@ -58,6 +58,16 @@ describe('Test for SeriesItem', () => {
             expect(seriesItem.label).toBe('10');
             expect(seriesItem.tooltipLabel).toBe('10');
         });
+
+        it('Changes to makingTooltip and changes to makingSeries should be distinguished.', () => {
+            seriesItem.formatFunctions = [(value, chartType, areaType) => (
+                areaType === 'makingSeriesLabel' ? `!!${value}` : `00${value}`
+            )];
+            seriesItem._initValues(10);
+
+            expect(seriesItem.label).toBe('!!10');
+            expect(seriesItem.tooltipLabel).toBe('0010');
+        });
     });
 
     describe('_createValues()', () => {

--- a/test/models/data/seriesItem.spec.js
+++ b/test/models/data/seriesItem.spec.js
@@ -20,6 +20,7 @@ describe('Test for SeriesItem', () => {
             expect(seriesItem.value).toBe(10);
             expect(seriesItem.end).toBe(10);
             expect(seriesItem.label).toBe('0010');
+            expect(seriesItem.tooltipLabel).toBe('0010');
             expect(seriesItem.endLabel).toBe('0010');
             expect(seriesItem.isRange).toBe(false);
         });
@@ -30,6 +31,7 @@ describe('Test for SeriesItem', () => {
             expect(seriesItem.end).toBe(null);
             expect(seriesItem.start).toBe(null);
             expect(seriesItem.label).toBe('');
+            expect(seriesItem.tooltipLabel).toBe('');
             expect(seriesItem.endLabel).toBe('');
             expect(seriesItem.startLabel).toBe(null);
             expect(seriesItem.isRange).toBe(false);
@@ -42,6 +44,7 @@ describe('Test for SeriesItem', () => {
             expect(seriesItem.end).toBe(40);
             expect(seriesItem.start).toBe(10);
             expect(seriesItem.label).toBe('0010 ~ 0040');
+            expect(seriesItem.tooltipLabel).toBe('0010 ~ 0040');
             expect(seriesItem.endLabel).toBe('0040');
             expect(seriesItem.startLabel).toBe('0010');
             expect(seriesItem.isRange).toBe(true);
@@ -53,6 +56,7 @@ describe('Test for SeriesItem', () => {
 
             expect(seriesItem.value).toBe(-10);
             expect(seriesItem.label).toBe('10');
+            expect(seriesItem.tooltipLabel).toBe('10');
         });
     });
 


### PR DESCRIPTION
## format 옵션으로 makingSeriesLabel 타입의 value를  변경하려고 하면 툴팁의 값이 같이 반영되는 문제

* SeriesItem.label 값과 SeriesItem.tooltipLabel 부분 분리
  1. normalTooltip에서 `SeriesItem.tooltipLabel` 값을 사용하려고 시도하는 부분이 코드에 있지만 모델(SeriesItem)에서 실제 데이터를 만들어 주고 있지 않는 부분을 확인 (원인파악).
  2. 모델(SeriesItem)이  tooltipLabel 프로퍼티를 만들어 주도록 수정
  3. groupTooltip에서도 `SeriesItem.tooltipLabel`의 값을 사용하도록 수정
  4. 테스트에 tooltopLabel 값 확인하도록 추가.
