### PR TITLE
fixed colorByPoint option

### DIFF
--- a/src/js/chart.js
+++ b/src/js/chart.js
@@ -149,7 +149,7 @@ function _createChart(container, rawData = {}, options, chartType) {
  *          @param {number} options.series.barWidth - bar width
  *          @param {boolean} options.series.allowSelect - whether allow select or not
  *          @param {boolean} options.series.diverging - whether diverging or not
- *          @param {number} options.series.colorByPoint - whether category Individual colors
+ *          @param {boolean} options.series.colorByPoint - whether category Individual colors
  *      @param {object} options.tooltip - options for tooltip component
  *          @param {string} options.tooltip.suffix - suffix for tooltip
  *          @param {function} [options.tooltip.template] - template for tooltip
@@ -252,7 +252,7 @@ function barChart(container, rawData, options) {
  *          @param {number} options.series.barWidth - bar width
  *          @param {boolean} options.series.allowSelect - whether allow select or not
  *          @param {boolean} options.series.diverging - whether diverging or not
- *          @param {number} options.series.colorByPoint - whether category Individual colors
+ *          @param {boolean} options.series.colorByPoint - whether category Individual colors
  *      @param {object} options.tooltip - options for tooltip component
  *          @param {string} options.tooltip.suffix - suffix for tooltip
  *          @param {function} [options.tooltip.template] - template for tooltip

--- a/src/js/chart.js
+++ b/src/js/chart.js
@@ -98,7 +98,8 @@ function _createChart(container, rawData = {}, options, chartType) {
     options.chartType = chartType;
     options.theme = options.theme || chartConst.DEFAULT_THEME_NAME;
 
-    const theme = themeManager.get(options.theme, chartType, rawData.series);
+    const isColorByPoint = options.series && options.series.colorByPoint;
+    const theme = themeManager.get(options.theme, chartType, rawData.series, isColorByPoint);
     const chart = chartFactory.get(options.chartType, rawData, theme, options);
 
     chart.render(container);
@@ -148,6 +149,7 @@ function _createChart(container, rawData = {}, options, chartType) {
  *          @param {number} options.series.barWidth - bar width
  *          @param {boolean} options.series.allowSelect - whether allow select or not
  *          @param {boolean} options.series.diverging - whether diverging or not
+ *          @param {number} options.series.colorByPoint - whether category Individual colors
  *      @param {object} options.tooltip - options for tooltip component
  *          @param {string} options.tooltip.suffix - suffix for tooltip
  *          @param {function} [options.tooltip.template] - template for tooltip
@@ -250,6 +252,7 @@ function barChart(container, rawData, options) {
  *          @param {number} options.series.barWidth - bar width
  *          @param {boolean} options.series.allowSelect - whether allow select or not
  *          @param {boolean} options.series.diverging - whether diverging or not
+ *          @param {number} options.series.colorByPoint - whether category Individual colors
  *      @param {object} options.tooltip - options for tooltip component
  *          @param {string} options.tooltip.suffix - suffix for tooltip
  *          @param {function} [options.tooltip.template] - template for tooltip

--- a/src/js/themes/themeManager.js
+++ b/src/js/themes/themeManager.js
@@ -184,12 +184,10 @@ export default {
         let seriesCount = 0;
 
         if (rawSeriesDatum && rawSeriesDatum.length) {
-            isColorByPoint = isColorByPoint && rawSeriesDatum[0] &&
-                rawSeriesDatum[0].data && rawSeriesDatum[0].data.length;
+            const existFirstSeriesDataLength = rawSeriesDatum[0] && rawSeriesDatum[0].data &&
+                rawSeriesDatum[0].data.length;
 
-            if (rawSeriesDatum.colorLength) {
-                seriesCount = rawSeriesDatum.colorLength;
-            } else if (isColorByPoint) {
+            if (isColorByPoint && existFirstSeriesDataLength) {
                 seriesCount = Math.max(rawSeriesDatum.length, rawSeriesDatum[0].data.length);
             } else {
                 seriesCount = rawSeriesDatum.length;
@@ -199,17 +197,6 @@ export default {
         return seriesCount;
     },
 
-    /**
-     * Init theme.
-     * @param {string} themeName - theme name
-     * @param {object} rawTheme - raw theme
-     * @param {Array.<string>} seriesTypes - series types
-     * @param {object} rawSeriesData - raw series data
-     * @param {boolean} isColorByPoint - check colorByPoint option
-     * @returns {object}
-     * @private
-     * @ignore
-     */
     _initTheme(themeName, rawTheme, seriesTypes, rawSeriesData, isColorByPoint) {
         let theme;
 

--- a/src/js/themes/themeManager.js
+++ b/src/js/themes/themeManager.js
@@ -143,9 +143,10 @@ export default {
      * @param {object} seriesThemes - series theme map
      * @param {object} rawSeriesThemes - raw series theme map
      * @param {object} rawSeriesData - raw series data
+     * @param {boolean} isColorByPoint - check colorByPoint option
      * @private
      */
-    _setSeriesColors(seriesTypes, seriesThemes, rawSeriesThemes, rawSeriesData) {
+    _setSeriesColors(seriesTypes, seriesThemes, rawSeriesThemes, rawSeriesData, isColorByPoint) {
         let seriesColors, seriesCount, hasOwnColors;
         let colorIndex = 0;
 
@@ -160,7 +161,7 @@ export default {
                 hasOwnColors = false;
             }
 
-            seriesCount = this._getSeriesThemeColorCount(rawSeriesData[seriesType]);
+            seriesCount = this._getSeriesThemeColorCount(rawSeriesData[seriesType], isColorByPoint);
 
             seriesThemes[seriesType].colors = this._makeEachSeriesColors(seriesColors, seriesCount,
                 !hasOwnColors && colorIndex);
@@ -175,15 +176,21 @@ export default {
     /**
      * Get number of series theme color from seriesData
      * @param {object} rawSeriesDatum - raw series data contains series information
+     * @param {boolean} isColorByPoint - check colorByPoint option
      * @returns {number} number of series theme color
      * @private
      */
-    _getSeriesThemeColorCount(rawSeriesDatum) {
+    _getSeriesThemeColorCount(rawSeriesDatum, isColorByPoint) {
         let seriesCount = 0;
 
         if (rawSeriesDatum && rawSeriesDatum.length) {
+            isColorByPoint = isColorByPoint && rawSeriesDatum[0] &&
+                rawSeriesDatum[0].data && rawSeriesDatum[0].data.length;
+
             if (rawSeriesDatum.colorLength) {
                 seriesCount = rawSeriesDatum.colorLength;
+            } else if (isColorByPoint) {
+                seriesCount = Math.max(rawSeriesDatum.length, rawSeriesDatum[0].data.length);
             } else {
                 seriesCount = rawSeriesDatum.length;
             }
@@ -198,11 +205,12 @@ export default {
      * @param {object} rawTheme - raw theme
      * @param {Array.<string>} seriesTypes - series types
      * @param {object} rawSeriesData - raw series data
+     * @param {boolean} isColorByPoint - check colorByPoint option
      * @returns {object}
      * @private
      * @ignore
      */
-    _initTheme(themeName, rawTheme, seriesTypes, rawSeriesData) {
+    _initTheme(themeName, rawTheme, seriesTypes, rawSeriesData, isColorByPoint) {
         let theme;
 
         if (themeName !== chartConst.DEFAULT_THEME_NAME) { // customized theme that overrides default theme
@@ -216,7 +224,7 @@ export default {
         theme.yAxis = this._createComponentThemeWithSeriesName(seriesTypes, rawTheme.yAxis, theme.yAxis, 'yAxis');
         theme.series = this._createComponentThemeWithSeriesName(seriesTypes, rawTheme.series, theme.series, 'series');
 
-        this._setSeriesColors(seriesTypes, theme.series, rawTheme.series, rawSeriesData);
+        this._setSeriesColors(seriesTypes, theme.series, rawTheme.series, rawSeriesData, isColorByPoint);
 
         return theme;
     },
@@ -296,9 +304,10 @@ export default {
      * @param {string} themeName - theme name
      * @param {string} chartType - chart type
      * @param {object} rawSeriesData - raw series data
+     * @param {boolean} isColorByPoint - check colorByPoint option
      * @returns {object}
      */
-    get(themeName, chartType, rawSeriesData) {
+    get(themeName, chartType, rawSeriesData, isColorByPoint) {
         const rawTheme = themes[themeName];
 
         if (!rawTheme) {
@@ -307,7 +316,7 @@ export default {
 
         const seriesTypes = this._pickSeriesNames(chartType, rawSeriesData);
 
-        const theme = this._initTheme(themeName, rawTheme, seriesTypes, rawSeriesData);
+        const theme = this._initTheme(themeName, rawTheme, seriesTypes, rawSeriesData, isColorByPoint);
 
         this._inheritThemeFont(theme, seriesTypes);
         this._copySeriesColorThemeToOther(theme);

--- a/test/themes/themeManager.spec.js
+++ b/test/themes/themeManager.spec.js
@@ -252,6 +252,20 @@ describe('Test for themeManager', () => {
         });
     });
 
+    describe('_getSeriesThemeColorCount()', () => {
+        it('Must be the same as the data length of one legend when value of isColorByPoint is true.', () => {
+            const rawSeriesDatum = [{
+                name: 'Budget',
+                data: [5000, 3000, 5000, 7000, 6000, 4000, 1000]
+            }];
+            const isColorByPoint = true;
+
+            const themeCount = themeManager._getSeriesThemeColorCount(rawSeriesDatum, isColorByPoint);
+
+            expect(themeCount).toBe(7);
+        });
+    });
+
     describe('_initTheme()', () => {
         it('init theme', () => {
             const themeName = 'newTheme';


### PR DESCRIPTION
## work
* series.colorByPoint 옵션 (범례가 하나일때 카테고리 별로 색상이 나오도록 하는 옵션) 이 적용되지 않는 부분 수정
  1. colorByPoint 옵션 적용중에는 themeManager._getSeriesThemeColorCount 가 카테고리 개수를 반환해야 함 - 재료가 되는 테마의 기본 색상 수가 모자르기 때문에 (원인파악).
  2. 잘 되던 시점의 깃헙 로그 찾아서 문제가 되는 부분 확인 하여 원복하고 추가로 `series.colorByPoint` 을 직접 확인하도록 조건문을 강화함.
  3. jsdoc에  `series.colorByPoint` 옵션 추가
