### PR TITLE
change findData algorithm

### DIFF
--- a/src/js/components/mouseEventDetectors/areaTypeEventDetector.js
+++ b/src/js/components/mouseEventDetectors/areaTypeEventDetector.js
@@ -8,6 +8,8 @@ import zoomMixer from './zoomMixer';
 import AreaTypeDataModel from './areaTypeDataModel';
 import snippet from 'tui-code-snippet';
 
+const AREA_DETECT_DISTANCE_THRESHOLD = 50;
+
 class AreaTypeEventDetector extends MouseEventDetectorBase {
     /**
      * AreaTypeEventDetector is mouse event detector for line type chart.
@@ -98,7 +100,7 @@ class AreaTypeEventDetector extends MouseEventDetectorBase {
         const layerPosition = this._calculateLayerPosition(clientX, clientY);
         const {selectLegendIndex} = this.dataProcessor;
 
-        return this.dataModel.findData(layerPosition, selectLegendIndex);
+        return this.dataModel.findData(layerPosition, AREA_DETECT_DISTANCE_THRESHOLD, selectLegendIndex);
     }
 
     /**

--- a/src/js/components/mouseEventDetectors/areaTypeEventDetector.js
+++ b/src/js/components/mouseEventDetectors/areaTypeEventDetector.js
@@ -8,8 +8,6 @@ import zoomMixer from './zoomMixer';
 import AreaTypeDataModel from './areaTypeDataModel';
 import snippet from 'tui-code-snippet';
 
-const AREA_DETECT_DISTANCE_THRESHHOLD = 50;
-
 class AreaTypeEventDetector extends MouseEventDetectorBase {
     /**
      * AreaTypeEventDetector is mouse event detector for line type chart.
@@ -100,7 +98,7 @@ class AreaTypeEventDetector extends MouseEventDetectorBase {
         const layerPosition = this._calculateLayerPosition(clientX, clientY);
         const {selectLegendIndex} = this.dataProcessor;
 
-        return this.dataModel.findData(layerPosition, AREA_DETECT_DISTANCE_THRESHHOLD, selectLegendIndex);
+        return this.dataModel.findData(layerPosition, selectLegendIndex);
     }
 
     /**

--- a/test/components/mouseEventDetectors/areaTypeDataModel.spec.js
+++ b/test/components/mouseEventDetectors/areaTypeDataModel.spec.js
@@ -67,7 +67,7 @@ describe('Test for AreaTypeDataModel', () => {
             const actual = dataModel.findData({
                 x: 17,
                 y: 10
-            }, null);
+            }, null, null);
             const [, expected] = dataModel.data;
             expect(actual).toBe(expected);
         });
@@ -95,7 +95,7 @@ describe('Test for AreaTypeDataModel', () => {
             const actual = dataModel.findData({
                 x: 17,
                 y: 10
-            }, null);
+            }, null, null);
             const [expected] = dataModel.data;
             expect(actual).toBe(expected);
         });

--- a/test/components/mouseEventDetectors/areaTypeDataModel.spec.js
+++ b/test/components/mouseEventDetectors/areaTypeDataModel.spec.js
@@ -45,7 +45,7 @@ describe('Test for AreaTypeDataModel', () => {
     });
 
     describe('findData()', () => {
-        it('find data', () => {
+        it('Find the data closest to the x coordinate.', () => {
             dataModel.data = [
                 {
                     bound: {
@@ -67,7 +67,35 @@ describe('Test for AreaTypeDataModel', () => {
             const actual = dataModel.findData({
                 x: 17,
                 y: 10
-            }, null, null);
+            }, null);
+            const [, expected] = dataModel.data;
+            expect(actual).toBe(expected);
+        });
+
+        it('Must be found the data closest to the y-coordinate when x-coordinates are the same.', () => {
+            dataModel.data = [
+                {
+                    bound: {
+                        top: 10,
+                        left: 10
+                    },
+                    indexes: {
+                        groupIndex: 0,
+                        index: 0
+                    }
+                },
+                {
+                    bound: {
+                        top: 20,
+                        left: 10
+                    }
+                }
+            ];
+
+            const actual = dataModel.findData({
+                x: 17,
+                y: 10
+            }, null);
             const [expected] = dataModel.data;
             expect(actual).toBe(expected);
         });


### PR DESCRIPTION
## work

* 기존 방식은 마우스 포지션에 x, y 좌표 와 데이터 좌표의 거리가 50px 안쪽에 해당하는 데이터 중, 가장 인접한 데이터를 찾기때문에 데이터가 빼곡히 있는 경우 일반적인 동작으로 생각하기에는 원치 않는 데이터의 툴팁이 나오는 경우가 있어서 버그로 인식된다. (원인 파악)

* areatype 차트에서 마우스 포지션에 해당하는 데이터를 찾는 방식을 x 포지션 중심으로 먼저 찾도록 변경
  -  마우스 좌표와 데이터 사이의 가로 폭 기준으로 가장 가까운 x좌표 후보군 중에 세로폭 기준에서 다시 찾도록 변경

-- 이슈내용 참고
![2018-11-15 1 36 20](https://user-images.githubusercontent.com/35218826/48530550-7dbfbe00-e8db-11e8-9987-2a566f3086d3.png)