### PR TITLE
Fix/legend calculate width

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,8 +17,7 @@ module.exports = {
   },
   'rules': {
       'prefer-destructuring': ['error', {
-          VariableDeclarator: {array: true, object: true},
-          AssignmentExpression: {array: false, object: false}
+          VariableDeclarator: {array: true, object: true}
       }]
   }
 };

--- a/src/js/models/bounds/legendCalculator.js
+++ b/src/js/models/bounds/legendCalculator.js
@@ -60,12 +60,11 @@ export default {
     /**
      * Divide legend labels.
      * @param {Array.<string>} labels legend labels
-     * @param {number} count division count
+     * @param {number} limitCount division limit count
      * @returns {Array.<Array.<string>>}
      * @private
      */
-    _divideLegendLabels(labels, count) {
-        const limitCount = Math.round(labels.length / count);
+    _divideLegendLabels(labels, limitCount) {
         const results = [];
         let temp = [];
 
@@ -113,21 +112,20 @@ export default {
      * @private
      */
     _makeDividedLabelsAndMaxLineWidth(labels, chartWidth, labelTheme, checkboxWidth, maxWidth) {
+        let limitCount = Number.MAX_VALUE;
         let divideCount = 1;
         let maxLineWidth = 0;
-        let prevMaxWidth = 0;
         let dividedLabels, prevLabels;
-
         do {
-            dividedLabels = this._divideLegendLabels(labels, divideCount);
+            limitCount = Math.round(labels.length / divideCount);
+            dividedLabels = this._divideLegendLabels(labels, limitCount);
             maxLineWidth = this._getMaxLineWidth(dividedLabels, labelTheme, checkboxWidth, maxWidth);
 
-            if (prevMaxWidth === maxLineWidth) {
+            if (limitCount === 1) {
                 dividedLabels = prevLabels;
                 break;
             }
 
-            prevMaxWidth = maxLineWidth;
             prevLabels = dividedLabels;
             divideCount += 1;
         } while (maxLineWidth >= chartWidth);

--- a/src/js/models/bounds/legendCalculator.js
+++ b/src/js/models/bounds/legendCalculator.js
@@ -112,21 +112,19 @@ export default {
      * @private
      */
     _makeDividedLabelsAndMaxLineWidth(labels, chartWidth, labelTheme, checkboxWidth, maxWidth) {
-        let limitCount = Number.MAX_VALUE;
+        let maxRowCount = Number.MAX_VALUE;
         let divideCount = 1;
         let maxLineWidth = 0;
-        let dividedLabels, prevLabels;
+        let dividedLabels;
         do {
-            limitCount = Math.round(labels.length / divideCount);
-            dividedLabels = this._divideLegendLabels(labels, limitCount);
+            maxRowCount = Math.round(labels.length / divideCount);
+            dividedLabels = this._divideLegendLabels(labels, maxRowCount);
             maxLineWidth = this._getMaxLineWidth(dividedLabels, labelTheme, checkboxWidth, maxWidth);
 
-            if (limitCount === 1) {
-                dividedLabels = prevLabels;
+            if (maxRowCount === 1) {
                 break;
             }
 
-            prevLabels = dividedLabels;
             divideCount += 1;
         } while (maxLineWidth >= chartWidth);
 

--- a/src/js/models/bounds/legendCalculator.js
+++ b/src/js/models/bounds/legendCalculator.js
@@ -60,16 +60,16 @@ export default {
     /**
      * Divide legend labels.
      * @param {Array.<string>} labels legend labels
-     * @param {number} limitCount division limit count
+     * @param {number} maxRowCount division limit count
      * @returns {Array.<Array.<string>>}
      * @private
      */
-    _divideLegendLabels(labels, limitCount) {
+    _divideLegendLabels(labels, maxRowCount) {
         const results = [];
         let temp = [];
 
         labels.forEach(label => {
-            if (temp.length < limitCount) {
+            if (temp.length < maxRowCount) {
                 temp.push(label);
             } else {
                 results.push(temp);

--- a/src/js/models/bounds/legendCalculator.js
+++ b/src/js/models/bounds/legendCalculator.js
@@ -126,8 +126,9 @@ export default {
             maxRowCount = Math.round(labels.length / divideCount);
             dividedLabels = this._divideLegendLabels(labels, maxRowCount);
             const legendWidthInfo = this._getLegendWidthInfo(dividedLabels, labelTheme, checkboxWidth, maxWidth);
-            lineWidths = legendWidthInfo.legendWidths;
-            labelWidths = legendWidthInfo.labelWidthArr;
+
+            ({legendWidths: lineWidths, labelWidthArr: labelWidths} = legendWidthInfo);
+
             maxLineWidth = arrayUtil.max(lineWidths);
 
             if (maxRowCount === 1) {
@@ -137,7 +138,7 @@ export default {
             divideCount += 1;
         } while (maxLineWidth >= chartWidth);
 
-        maxLineWidth = maxLineWidth > chartWidth ? chartWidth : maxLineWidth;
+        maxLineWidth = Math.min(maxLineWidth, chartWidth);
 
         return {
             labels: this._optimizedHorizontalLegendLabels(labels, labelWidths, maxLineWidth),
@@ -155,13 +156,16 @@ export default {
      */
     _optimizedHorizontalLegendLabels(labels, labelWidths, maxLineWidth) {
         const optimizedDvidedLabels = [];
+        const labelsLastIdx = labels.length - 1;
         let sum = 0;
         let temp = [];
+
         labels.forEach((label, labelIdx) => {
             const labelWidth = labelWidths[labelIdx];
             const paddingWidth = LEGEND_AREA_H_PADDING - LEGEND_H_LABEL_RIGHT_PADDING;
+            const predictedLineWidth = sum + labelWidth + paddingWidth;
 
-            if (sum + labelWidth + paddingWidth <= maxLineWidth) {
+            if (predictedLineWidth <= maxLineWidth) {
                 temp.push(label);
             } else {
                 optimizedDvidedLabels.push(temp);
@@ -171,7 +175,7 @@ export default {
 
             sum += labelWidth;
 
-            if (labels.length - 1 === labelIdx) {
+            if (labelsLastIdx === labelIdx) {
                 optimizedDvidedLabels.push(temp);
             }
         });

--- a/test/models/bounds/legendCalculator.spec.js
+++ b/test/models/bounds/legendCalculator.spec.js
@@ -32,15 +32,15 @@ describe('Test for legendCalculator', () => {
             expect(actual).toEqual(expected);
         });
 
-        it('divide legend labels, when count for dividing is three', () => {
-            const actual = legendCalculator._divideLegendLabels(['ABC1', 'ABC2', 'ABC3', 'ABC4', 'ABC5'], 3);
+        it('Should return an array detached with maxRows.', () => {
+            const actual = legendCalculator._divideLegendLabels(['ABC1', 'ABC2', 'ABC3', 'ABC4', 'ABC5'], 2);
             const expected = [['ABC1', 'ABC2'], ['ABC3', 'ABC4'], ['ABC5']];
 
             expect(actual).toEqual(expected);
         });
 
-        it('if count is one, retuns original labels', () => {
-            const actual = legendCalculator._divideLegendLabels(['ABC1', 'ABC2', 'ABC3', 'ABC4'], 1);
+        it('if maxRows is equal to the number of labels, retuns original labels', () => {
+            const actual = legendCalculator._divideLegendLabels(['ABC1', 'ABC2', 'ABC3', 'ABC4'], 4);
             const expected = [['ABC1', 'ABC2', 'ABC3', 'ABC4']];
 
             expect(actual).toEqual(expected);
@@ -65,11 +65,12 @@ describe('Test for legendCalculator', () => {
         });
 
         it('make divided labels and max line width, when chart width less than label width', () => {
+            const checkboxWidth = chartConst.LEGEND_CHECKBOX_SIZE + chartConst.LEGEND_LABEL_LEFT_PADDING;
             const actual = legendCalculator._makeDividedLabelsAndMaxLineWidth(
-                ['ABC1', 'ABC2', 'ABC3', 'ABC4', 'ABC5'], 130, {}, chartConst.LEGEND_CHECKBOX_SIZE + chartConst.LEGEND_LABEL_LEFT_PADDING
+                ['ABC1', 'ABC2', 'ABC3', 'ABC4', 'ABC5'], 130, {}, checkboxWidth
             );
             const expected = {
-                labels: [['ABC1'], ['ABC2'], ['ABC3'], ['ABC4'], ['ABC5']],
+                labels: [['ABC1', 'ABC2'], ['ABC3', 'ABC4'], ['ABC5']],
                 maxLineWidth: 120 /* width of a legend item */
             };
 

--- a/test/models/bounds/legendCalculator.spec.js
+++ b/test/models/bounds/legendCalculator.spec.js
@@ -13,14 +13,13 @@ describe('Test for legendCalculator', () => {
         spyOn(renderUtil, 'getRenderedLabelHeight').and.returnValue(20);
     });
 
-    describe('_calculateLegendsWidthSum()', () => {
+    describe('_calculateLegendsWidth()', () => {
         it('calculate sum of legends width', () => {
-            const actual = legendCalculator._calculateLegendsWidthSum(
+            const actual = legendCalculator._calculateLegendsWidth(
                 ['legend1', 'legend2'], {}, chartConst.LEGEND_CHECKBOX_SIZE + chartConst.LEGEND_LABEL_LEFT_PADDING
             );
-            const expected = 250;
 
-            expect(actual).toBe(expected);
+            expect(actual).toEqual([130, 130]);
         });
     });
 
@@ -56,6 +55,7 @@ describe('Test for legendCalculator', () => {
             const actual = legendCalculator._makeDividedLabelsAndMaxLineWidth(
                 ['ABC1', 'ABC2', 'ABC3', 'ABC4', 'ABC5'], 261, {}, chartConst.LEGEND_CHECKBOX_SIZE + chartConst.LEGEND_LABEL_LEFT_PADDING
             );
+
             const expected = {
                 labels: [['ABC1', 'ABC2'], ['ABC3', 'ABC4'], ['ABC5']],
                 maxLineWidth: 250 /* max line width */
@@ -68,12 +68,21 @@ describe('Test for legendCalculator', () => {
             const actual = legendCalculator._makeDividedLabelsAndMaxLineWidth(
                 ['ABC1', 'ABC2', 'ABC3', 'ABC4', 'ABC5'], 130, {}, chartConst.LEGEND_CHECKBOX_SIZE + chartConst.LEGEND_LABEL_LEFT_PADDING
             );
+
             const expected = {
                 labels: [['ABC1'], ['ABC2'], ['ABC3'], ['ABC4'], ['ABC5']],
                 maxLineWidth: 120 /* width of a legend item */
             };
 
             expect(actual).toEqual(expected);
+        });
+
+        it('Width of a label should not exceed the width of the chart.', () => {
+            const actual = legendCalculator._makeDividedLabelsAndMaxLineWidth(
+                ['ABC1'], 110, {}, chartConst.LEGEND_CHECKBOX_SIZE + chartConst.LEGEND_LABEL_LEFT_PADDING
+            );
+
+            expect(actual.maxLineWidth).toBe(110);
         });
     });
 

--- a/test/models/bounds/legendCalculator.spec.js
+++ b/test/models/bounds/legendCalculator.spec.js
@@ -65,12 +65,11 @@ describe('Test for legendCalculator', () => {
         });
 
         it('make divided labels and max line width, when chart width less than label width', () => {
-            const checkboxWidth = chartConst.LEGEND_CHECKBOX_SIZE + chartConst.LEGEND_LABEL_LEFT_PADDING;
             const actual = legendCalculator._makeDividedLabelsAndMaxLineWidth(
-                ['ABC1', 'ABC2', 'ABC3', 'ABC4', 'ABC5'], 130, {}, checkboxWidth
+                ['ABC1', 'ABC2', 'ABC3', 'ABC4', 'ABC5'], 130, {}, chartConst.LEGEND_CHECKBOX_SIZE + chartConst.LEGEND_LABEL_LEFT_PADDING
             );
             const expected = {
-                labels: [['ABC1', 'ABC2'], ['ABC3', 'ABC4'], ['ABC5']],
+                labels: [['ABC1'], ['ABC2'], ['ABC3'], ['ABC4'], ['ABC5']],
                 maxLineWidth: 120 /* width of a legend item */
             };
 


### PR DESCRIPTION
## Legend 넓기 계산식 수정
1.  `_makeDividedLabelsAndMaxLineWidth` 레전드 표의 한줄에 보여줄 넓이(maxLineWidth) 를 구하는 부분의 루프를 탈출하는 조건문이 잘못되었음, 충분히 최적화 되지 않아도 이전 루프의 maxLineWidth 와 현재 루프의 maxLineWidth 값이 같아지면 루프에서 빠져나오는 문제. - (원인파악)

2.  루프 탈출 조건을 바꿈 - MaxRows 카운트가 1이 되었을때야 말로 maxLineWidth 넒이를 더 최적화 할 여지가 없어지는 것으로 판단하여 루프를 빠져나옴.

## Legend 높이 계산식 수정
1. `_makeDividedLabelsAndMaxLineWidth` 메서드의 dividedLabels 값은 maxLineWidth를 구하기 위한 값일 뿐이라서 Legend 높이 계산에 그대로 사용되면 안되지만 사용되고 있는 문제가 있었다. - (원인파악)

2.  dividedLabels 값 대신  _optimizedHorizontalLegendLabels 로 한번 더 최적화 해준 값을 사용하도록 변경. 



-- 버그상황 
![2018-11-15 1 38 17](https://user-images.githubusercontent.com/35218826/48530604-bd86a580-e8db-11e8-91e6-8af54ca71cc2.png)