### PR TITLE
feat: add ratio for chart.format

### DIFF
--- a/src/js/charts/chartBase.js
+++ b/src/js/charts/chartBase.js
@@ -361,7 +361,13 @@ class ChartBase {
             this.prevXAxisData = boundsAndScale.axisDataMap.xAxis;
         }
 
-        this.addDataRatios(boundsAndScale.limitMap);
+        const isPieDonumCombo = predicate.isPieDonutComboChart(this.chartType, this.chartTypes);
+        const isPie = predicate.isPieChart(this.chartType);
+        const isPieSeriesChart = isPieDonumCombo || isPie;
+
+        if (!isPieSeriesChart) {
+            this.addDataRatios(boundsAndScale.limitMap);
+        }
 
         return boundsAndScale;
     }

--- a/src/js/charts/pieChart.js
+++ b/src/js/charts/pieChart.js
@@ -49,14 +49,6 @@ class PieChart extends ChartBase {
         this.componentManager.register('tooltip', 'tooltip');
         this.componentManager.register('mouseEventDetector', 'mouseEventDetector');
     }
-
-    /**
-     * Add data ratios.
-     * @override
-     */
-    addDataRatios() {
-        this.dataProcessor.addDataRatiosOfPieChart(this.chartType);
-    }
 }
 
 export default PieChart;

--- a/src/js/helpers/renderUtil.js
+++ b/src/js/helpers/renderUtil.js
@@ -396,11 +396,12 @@ const renderUtil = {
             valueType = 'value',
             areaType,
             legendName,
-            chartType
+            chartType,
+            ratio = null
         } = params;
         const fns = [String(value), ...formatFunctions || []];
 
-        return snippet.reduce(fns, (stored, fn) => fn(stored, chartType, areaType, valueType, legendName));
+        return snippet.reduce(fns, (stored, fn) => fn(stored, chartType, areaType, valueType, legendName, ratio));
     },
     /**
      * Format values.

--- a/src/js/models/data/dataProcessor.js
+++ b/src/js/models/data/dataProcessor.js
@@ -1251,14 +1251,6 @@ class DataProcessor extends DataProcessorBase {
     }
 
     /**
-     * Add data ratios of pie chart.
-     * @param {string} chartType - type of chart.
-     */
-    addDataRatiosOfPieChart(chartType) {
-        this.getSeriesDataModel(chartType).addDataRatiosOfPieChart();
-    }
-
-    /**
      * Add data ratios for chart of coordinate type.
      * @param {string} chartType - type of chart.
      * @param {{x: {min: number, max: number}, y: {min: number, max: number}}} limitMap - limit map

--- a/src/js/models/data/seriesDataModel.js
+++ b/src/js/models/data/seriesDataModel.js
@@ -541,6 +541,11 @@ class SeriesDataModel {
         }
     }
 
+    /**
+     * Calculate total value for pie chart
+     * @returns {number}
+     * @private
+     */
     caculateTotalValueForPieChart() {
         return calculator.sum(this.rawSeriesData.map(rawDatum => {
             let data = snippet.isArray(rawDatum) ? rawDatum : [].concat(rawDatum.data);

--- a/src/js/models/data/seriesDataModel.js
+++ b/src/js/models/data/seriesDataModel.js
@@ -164,6 +164,8 @@ class SeriesDataModel {
             sortValues = function() {};
         }
 
+        const totalValueForPieChart = isPieChart ? this.caculateTotalValueForPieChart() : null;
+
         return this.rawSeriesData.map(rawDatum => {
             let stack, data, legendName;
 
@@ -190,7 +192,8 @@ class SeriesDataModel {
                     stack,
                     isDivergingChart,
                     xAxisType: xAxisOption.type,
-                    dateFormat: xAxisOption.dateFormat
+                    dateFormat: xAxisOption.dateFormat,
+                    totalValue: totalValueForPieChart
                 })
             ));
             sortValues(items);
@@ -538,6 +541,16 @@ class SeriesDataModel {
         }
     }
 
+    caculateTotalValueForPieChart() {
+        return calculator.sum(this.rawSeriesData.map(rawDatum => {
+            let data = snippet.isArray(rawDatum) ? rawDatum : [].concat(rawDatum.data);
+
+            data = snippet.filter(data, snippet.isExisty);
+
+            return data[0];
+        }));
+    }
+
     /**
      * Add data ratios of pie chart.
      */
@@ -620,7 +633,6 @@ class SeriesDataModel {
      */
     each(iteratee, isPivot) {
         const groups = isPivot ? this._getPivotGroups() : this._getSeriesGroups();
-
         groups.forEach((seriesGroup, index) => iteratee(seriesGroup, index));
     }
 

--- a/src/js/models/data/seriesDataModel.js
+++ b/src/js/models/data/seriesDataModel.js
@@ -557,17 +557,6 @@ class SeriesDataModel {
     }
 
     /**
-     * Add data ratios of pie chart.
-     */
-    addDataRatiosOfPieChart() {
-        this.each(seriesGroup => {
-            const sum = calculator.sum(seriesGroup.pluck('value'));
-
-            seriesGroup.addRatios(sum);
-        });
-    }
-
-    /**
      * Add ratios of data for chart of coordinate type.
      * @param {{x: {min: number, max: number}, y: {min: number, max: number}}} limitMap - limit map
      * @param {boolean} [hasRadius] - whether has radius or not

--- a/src/js/models/data/seriesGroup.js
+++ b/src/js/models/data/seriesGroup.js
@@ -238,6 +238,8 @@ class SeriesGroup {
     pluck(key) {
         const items = this.items.filter(snippet.isExisty);
 
+        console.log("ITEMS - ",items);
+
         return snippet.pluck(items, key);
     }
 

--- a/src/js/models/data/seriesGroup.js
+++ b/src/js/models/data/seriesGroup.js
@@ -238,8 +238,6 @@ class SeriesGroup {
     pluck(key) {
         const items = this.items.filter(snippet.isExisty);
 
-        console.log("ITEMS - ",items);
-
         return snippet.pluck(items, key);
     }
 

--- a/src/js/models/data/seriesItem.js
+++ b/src/js/models/data/seriesItem.js
@@ -135,6 +135,10 @@ class SeriesItem {
          */
         this.legendName = params.legendName;
 
+        /**
+         * total value of series data
+         * @type {number}
+         */
         this.totalValue = params.totalValue;
 
         this._initValues(params.datum, params.index);

--- a/src/js/models/data/seriesItem.js
+++ b/src/js/models/data/seriesItem.js
@@ -135,6 +135,8 @@ class SeriesItem {
          */
         this.legendName = params.legendName;
 
+        this.totalValue = params.totalValue;
+
         this._initValues(params.datum, params.index);
     }
 
@@ -152,6 +154,10 @@ class SeriesItem {
         this.value = this.end = value;
         this.index = index;
 
+        if (predicate.isPieChart(this.chartType)) {
+            this.addRatio(this.totalValue);
+        }
+
         if (this.isDivergingChart) {
             value = Math.abs(value);
         }
@@ -165,7 +171,8 @@ class SeriesItem {
                     formatFunctions: this.formatFunctions,
                     chartType: this.chartType,
                     areaType: labelType === 'tooltipLabel' ? 'makingTooltipLabel' : 'makingSeriesLabel',
-                    legendName: this.legendName
+                    legendName: this.legendName,
+                    ratio: this.ratio
                 });
             });
         }

--- a/test/helpers/renderUtil.spec.js
+++ b/test/helpers/renderUtil.spec.js
@@ -112,6 +112,16 @@ describe('Test for renderUtil', () => {
             });
             expect(spy.calls.mostRecent().args[4]).toBe('newLegend');
         });
+
+        it('ratio argument is present, it should be returned.', () => {
+            const spy = jasmine.createSpy('spy');
+            renderUtil.formatValue({
+                value: 3,
+                formatFunctions: [spy],
+                ratio: 0.33
+            });
+            expect(spy.calls.mostRecent().args[5]).toBe(0.33);
+        });
     });
 
     describe('formatValues()', () => {

--- a/test/models/data/seriesDataModel.spec.js
+++ b/test/models/data/seriesDataModel.spec.js
@@ -534,18 +534,6 @@ describe('Test for SeriesDataModel', () => {
         });
     });
 
-    describe('addDataRatiosOfPieChart()', () => {
-        it('should call addRatios() with all series group values, when pie chart', () => {
-            const seriesGroup = jasmine.createSpyObj('seriesGroup', ['pluck', 'addRatios']);
-
-            seriesDataModel.groups = [seriesGroup];
-            seriesGroup.pluck.and.returnValue([10, 20, 30, 40]);
-            seriesDataModel.addDataRatiosOfPieChart();
-
-            expect(seriesGroup.addRatios).toHaveBeenCalledWith(100);
-        });
-    });
-
     describe('addDataRatiosForCoordinateType()', () => {
         it('should set x ratio using xDistance and xSubstraction values from limitMap.x', () => {
             const limitMap = {

--- a/test/models/data/seriesDataModel.spec.js
+++ b/test/models/data/seriesDataModel.spec.js
@@ -103,6 +103,21 @@ describe('Test for SeriesDataModel', () => {
             expect(actual[1][0].value).toBe(20);
         });
 
+        it('should contain a ratio property at pie chart.', () => {
+            seriesDataModel.chartType = 'pie';
+            seriesDataModel.rawSeriesData = [{
+                data: 50
+            }, {
+                data: 20
+            }, {
+                data: 70
+            }];
+
+            const actual = seriesDataModel._createBaseGroups();
+
+            expect(actual[0][0].ratio.toFixed(2)).toBe('0.36');
+        });
+
         it('should not create item when pie data is null.', () => {
             seriesDataModel.chartType = 'pie';
             seriesDataModel.rawSeriesData = [{


### PR DESCRIPTION
![2018-12-28 10 21 10](https://user-images.githubusercontent.com/35218826/50499143-939fd180-0a8a-11e9-91ff-7cdcf6a3635a.png)

위와같이 값의 비율이 작으면 정상적인 표현이 안되므로

* 파이 차트의 경우 chart.format 옵션 함수의 인자로 ratio값을 추가 하여 사용자가 아래와 같이 필터링 할수 있도록 함
```js
var options = {
        format: function(value, chartType, areaType, valuetype, legendName, ratio) {
            if (areaType === 'makingSeriesLabel' && ratio < 0.20) { 
                value = '';
            }

            return value;
        }
}
```
*  기존에는 `chart.format` 함수의 실행 후에 ratio값을 계산하므로 인자로 전달할수 없음
    * 그래서 파이차트의 경우에는 ratio값을 미리 계산 하도록 수정


