### PR TITLE
fix: yAxisAreaWidth incorrect caculate

### DIFF
--- a/src/js/models/scaleData/axisDataMaker.js
+++ b/src/js/models/scaleData/axisDataMaker.js
@@ -78,7 +78,7 @@ const axisDataMaker = {
             tickCount += 1;
         }
 
-        const result = {
+        return {
             labels,
             tickCount,
             validTickCount: tickCount,
@@ -88,8 +88,6 @@ const axisDataMaker = {
             isPositionRight: !!params.isPositionRight,
             aligned: !!params.aligned
         };
-
-        return result;
     },
 
     /**

--- a/src/js/models/scaleData/axisDataMaker.js
+++ b/src/js/models/scaleData/axisDataMaker.js
@@ -78,7 +78,7 @@ const axisDataMaker = {
             tickCount += 1;
         }
 
-        return {
+        const result = {
             labels,
             tickCount,
             validTickCount: tickCount,
@@ -88,6 +88,8 @@ const axisDataMaker = {
             isPositionRight: !!params.isPositionRight,
             aligned: !!params.aligned
         };
+
+        return result;
     },
 
     /**
@@ -538,7 +540,8 @@ const axisDataMaker = {
     makeAdditionalDataForRotatedLabels(validLabels, validLabelCount, labelTheme, isLabelAxis, dimensionMap) {
         const maxLabelWidth = renderUtil.getRenderedLabelsMaxWidth(validLabels, labelTheme);
         const seriesWidth = dimensionMap.series.width;
-        const yAxisAreaWidth = dimensionMap.yAxis.width + dimensionMap.rightYAxis ? dimensionMap.rightYAxis.width : 0;
+        const yAxisAreaWidth = dimensionMap.yAxis.width + (dimensionMap.rightYAxis ? dimensionMap.rightYAxis.width : 0);
+
         let labelAreaWidth = this._calculateXAxisLabelAreaWidth(isLabelAxis, seriesWidth, validLabelCount);
         let additionalData = null;
         let contentWidth = (chartConst.CHART_PADDING * 2) + yAxisAreaWidth + seriesWidth;

--- a/test/models/scaleData/axisDataMaker.spec.js
+++ b/test/models/scaleData/axisDataMaker.spec.js
@@ -418,7 +418,7 @@ describe('Test for axisDataMaker', () => {
                 degree: 45,
                 overflowHeight: 10,
                 overflowLeft: -40,
-                overflowRight: -70
+                overflowRight: 30
             });
         });
 
@@ -447,7 +447,7 @@ describe('Test for axisDataMaker', () => {
 
             expect(actual).toEqual({
                 overflowLeft: -40,
-                overflowRight: 40
+                overflowRight: 140
             });
         });
     });


### PR DESCRIPTION
![2018-12-28 12 11 37](https://user-images.githubusercontent.com/35218826/50501470-bbe3fc00-0a9b-11e9-8489-4a93c320ed7f.png)

## 증상
* 위와 같이 가장 오른쪽 카테고리 레이블이 살짝 잘려보임

## 수정
* x축 전체 폭 계산에 영향을 미치는 y축 영역의 값이 잘못 계산되는 부분 발견하여 수정 
   * y축 영역을 계산할때 y축의 오른쪽 보조축이 없을경우에는 항상 0으로 계산되는 버그가 있었음.
