### PR TITLE
feat: tooltip mouse event search for coordinate type chart

### DIFF
--- a/src/js/components/mouseEventDetectors/areaTypeDataModel.js
+++ b/src/js/components/mouseEventDetectors/areaTypeDataModel.js
@@ -80,16 +80,19 @@ class AreaTypeDataModel {
     /**
      * Find Data by layer position.
      * @param {{x: number, y: number}} layerPosition - layer position
+     * @param {number} [selectLegendIndex] select legend sereis index
      * @param {number} [distanceLimit] distance limitation to find data
-     * @param {number} selectLegendIndex select legend sereis index
      * @returns {object}
      */
-    findData(layerPosition, distanceLimit, selectLegendIndex) {
-        if (distanceLimit && distanceLimit < this.leftStepLength) {
-            return this._findDataForLooseArea(layerPosition, distanceLimit, selectLegendIndex);
+    findData(layerPosition, selectLegendIndex, {distanceLimit, isCoordinateTypeChart} = {}) {
+        const isLooseDistancePosition = distanceLimit && distanceLimit < this.leftStepLength;
+        const useCoordinateDistanceSearch = isCoordinateTypeChart || isLooseDistancePosition;
+
+        if (useCoordinateDistanceSearch) {
+            return this._findDataForCoordinateDistance(layerPosition, distanceLimit, selectLegendIndex);
         }
 
-        return this._findDataForDenseArea(layerPosition, selectLegendIndex);
+        return this._findDataForFirstXPosition(layerPosition, selectLegendIndex);
     }
 
     /**
@@ -99,7 +102,7 @@ class AreaTypeDataModel {
      * @returns {object}
      * @private
      */
-    _findDataForDenseArea(layerPosition, selectLegendIndex) {
+    _findDataForFirstXPosition(layerPosition, selectLegendIndex) {
         const {xMinValue} = this.data.reduce((findMinObj, datum) => {
             const xDiff = Math.abs(layerPosition.x - datum.bound.left);
             if (xDiff <= findMinObj.xMin) {
@@ -146,7 +149,7 @@ class AreaTypeDataModel {
      * @returns {object}
      * @private
      */
-    _findDataForLooseArea(layerPosition, distanceLimit, selectLegendIndex) {
+    _findDataForCoordinateDistance(layerPosition, distanceLimit, selectLegendIndex) {
         let min = 100000;
         let findFound;
 

--- a/src/js/components/mouseEventDetectors/areaTypeDataModel.js
+++ b/src/js/components/mouseEventDetectors/areaTypeDataModel.js
@@ -81,7 +81,9 @@ class AreaTypeDataModel {
      * Find Data by layer position.
      * @param {{x: number, y: number}} layerPosition - layer position
      * @param {number} [selectLegendIndex] select legend sereis index
-     * @param {number} [distanceLimit] distance limitation to find data
+     * @param {object} [searchInfo] distance limitation to find data
+     *   @param {number} searchInfo.distanceLimit distance limitation to find data
+     *   @param {boolean} searchInfo.isCoordinateTypeChart whether coordinate type chart or not
      * @returns {object}
      */
     findData(layerPosition, selectLegendIndex, {distanceLimit, isCoordinateTypeChart} = {}) {

--- a/src/js/components/mouseEventDetectors/areaTypeEventDetector.js
+++ b/src/js/components/mouseEventDetectors/areaTypeEventDetector.js
@@ -99,8 +99,12 @@ class AreaTypeEventDetector extends MouseEventDetectorBase {
     _findData(clientX, clientY) {
         const layerPosition = this._calculateLayerPosition(clientX, clientY);
         const {selectLegendIndex} = this.dataProcessor;
+        const isCoordinateTypeChart = this.dataProcessor.isCoordinateType();
 
-        return this.dataModel.findData(layerPosition, AREA_DETECT_DISTANCE_THRESHOLD, selectLegendIndex);
+        return this.dataModel.findData(layerPosition, selectLegendIndex, {
+            distanceLimit: AREA_DETECT_DISTANCE_THRESHOLD,
+            isCoordinateTypeChart
+        });
     }
 
     /**

--- a/test/components/mouseEventDetectors/areaTypeDataModel.spec.js
+++ b/test/components/mouseEventDetectors/areaTypeDataModel.spec.js
@@ -45,7 +45,7 @@ describe('Test for AreaTypeDataModel', () => {
     });
 
     describe('findData()', () => {
-        it('Find the data closest to the x coordinate.', () => {
+        it('Find the data closest to the x coordinate at not coordinate type chart.', () => {
             dataModel.data = [
                 {
                     bound: {
@@ -67,12 +67,40 @@ describe('Test for AreaTypeDataModel', () => {
             const actual = dataModel.findData({
                 x: 17,
                 y: 10
-            }, null, null);
+            }, null, {
+                isCoordinateTypeChart: false
+            });
             const [, expected] = dataModel.data;
             expect(actual).toBe(expected);
         });
 
-        it('Must be found the data closest to the y-coordinate when x-coordinates are the same.', () => {
+        it('Find the data closest coordinate position at coordinate type chart.', () => {
+            dataModel.data = [
+                {
+                    bound: {
+                        top: 10,
+                        left: 10
+                    }
+                },
+                {
+                    bound: {
+                        top: 20,
+                        left: 20
+                    }
+                }
+            ];
+            const actual = dataModel.findData({
+                x: 17,
+                y: 10
+            }, null, {
+                isCoordinateTypeChart: true
+            });
+            const [expected] = dataModel.data;
+
+            expect(actual).toBe(expected);
+        });
+
+        it('Must be found the data closest to the y-coordinate when x-coordinates are the same and not coordinate type chart.', () => {
             dataModel.data = [
                 {
                     bound: {
@@ -95,7 +123,9 @@ describe('Test for AreaTypeDataModel', () => {
             const actual = dataModel.findData({
                 x: 17,
                 y: 10
-            }, null, null);
+            }, null, {
+                isCoordinateTypeChart: false
+            });
             const [expected] = dataModel.data;
             expect(actual).toBe(expected);
         });

--- a/test/components/mouseEventDetectors/areaTypeDataModel.spec.js
+++ b/test/components/mouseEventDetectors/areaTypeDataModel.spec.js
@@ -106,10 +106,6 @@ describe('Test for AreaTypeDataModel', () => {
                     bound: {
                         top: 10,
                         left: 10
-                    },
-                    indexes: {
-                        groupIndex: 0,
-                        index: 0
                     }
                 },
                 {
@@ -121,12 +117,12 @@ describe('Test for AreaTypeDataModel', () => {
             ];
 
             const actual = dataModel.findData({
-                x: 17,
-                y: 10
+                x: 10,
+                y: 17
             }, null, {
                 isCoordinateTypeChart: false
             });
-            const [expected] = dataModel.data;
+            const [, expected] = dataModel.data;
             expect(actual).toBe(expected);
         });
     });


### PR DESCRIPTION
![2019-01-03 5 01 15](https://user-images.githubusercontent.com/35218826/50627945-3b306e80-0f79-11e9-80a5-4fd75a8c9ca6.png)

## 현상과 원인
* 라인차트에서 데이터 간격이 조밀한 데이터 탐색의 경우 `x좌표 우선 탐색`이 적용된다. 하지만 데이터에 x,y 좌표를 사용하는 좌표계 라인 차트에서는 위와 같이 한쪽 데이터의 x포지션이 없는 구간일 경우 회색라인에 마우스가 가깝지만 파란라인에 툴팁이 보여질수 있어서 버그처럼 보일 수 있다.

## 해결
* 좌표계 차트는 `x좌표 우선 탐색` 대신, 데이터의 x y 포지션과 마우스 포인트와의 절대 거리를 중심으로 탐색하는`좌표 거리 탐색` 이 적용되도록 변경하여 해결.
