### PR TITLE
fix: event position calculation after `rerender`

### DIFF
--- a/src/js/components/mouseEventDetectors/mouseEventDetectorBase.js
+++ b/src/js/components/mouseEventDetectors/mouseEventDetectorBase.js
@@ -277,6 +277,8 @@ class MouseEventDetectorBase {
     rerender(data) {
         let tickCount;
 
+        this.positionMap = data.positionMap;
+
         if (data.axisDataMap.xAxis) {
             tickCount = this._pickTickCount(data.axisDataMap);
         }

--- a/src/js/plugins/raphaelLineTypeBase.js
+++ b/src/js/plugins/raphaelLineTypeBase.js
@@ -7,6 +7,7 @@ import raphaelRenderUtil from './raphaelRenderUtil';
 import renderUtil from '../helpers/renderUtil';
 import predicate from '../helpers/predicate';
 import arrayUtil from '../helpers/arrayUtil';
+import chartConst from '../const';
 import snippet from 'tui-code-snippet';
 
 const {browser} = snippet;
@@ -785,16 +786,20 @@ class RaphaelLineTypeBase {
     animate(onFinish, seriesSet) {
         const {paper, dimension, position} = this;
         const clipRectId = this._getClipRectId();
+        const remakePosition = this._makeClipRectPosition(position);
         let {clipRect} = this;
 
         if (!IS_LTE_IE8 && dimension) {
             if (!clipRect) {
-                clipRect = createClipPathRectWithLayout(paper, position, dimension, clipRectId);
+                clipRect = createClipPathRectWithLayout(paper, remakePosition, dimension, clipRectId);
                 this.clipRect = clipRect;
             } else {
+                this._makeClipRectPosition(position);
                 clipRect.attr({
                     width: 0,
-                    height: dimension.height
+                    height: dimension.height,
+                    x: remakePosition.left,
+                    y: remakePosition.top
                 });
             }
 
@@ -806,6 +811,21 @@ class RaphaelLineTypeBase {
                 width: dimension.width
             }, ANIMATION_DURATION, '>', onFinish);
         }
+    }
+
+    /**
+     * Make selection dot.
+     * @param {object} position clip rect position
+     *   @param {number} left clip rect left position
+     *   @param {number} top clip rect top position
+     * @returns {{top: number, left: number}} remake clip rect position
+     * @private
+     */
+    _makeClipRectPosition(position) {
+        return {
+            left: position.left - chartConst.SERIES_EXPAND_SIZE,
+            top: position.top - chartConst.SERIES_EXPAND_SIZE
+        };
     }
 
     /**
@@ -1004,7 +1024,7 @@ class RaphaelLineTypeBase {
  */
 function createClipPathRectWithLayout(paper, position, dimension, id) {
     const clipPath = document.createElementNS('http://www.w3.org/2000/svg', 'clipPath');
-    const rect = paper.rect((position.left - 10), (position.top - 10), 0, dimension.height);
+    const rect = paper.rect(position.left, position.top, 0, dimension.height);
 
     rect.id = `${id}_rect`;
     clipPath.id = id;

--- a/test/plugins/raphaelLineTypeBase.spec.js
+++ b/test/plugins/raphaelLineTypeBase.spec.js
@@ -276,7 +276,7 @@ describe('RaphaelLineTypeBase', () => {
             const [callArgument] = lineTypeBase.clipRect.attr.calls.mostRecent().args;
 
             expect(callArgument.x).toBe(20);
-            expect(callArgument.x).toBe(30);
+            expect(callArgument.y).toBe(30);
         });
     });
 });

--- a/test/plugins/raphaelLineTypeBase.spec.js
+++ b/test/plugins/raphaelLineTypeBase.spec.js
@@ -259,4 +259,24 @@ describe('RaphaelLineTypeBase', () => {
             expect(actual).toBe('item1');
         });
     });
+    describe('animate()', () => {
+        it('ClipRect should always be updated to reflect x, y.', () => {
+            lineTypeBase.clipRect = jasmine.createSpyObj('clipRect', ['attr', 'animate']);
+            lineTypeBase.paper = raphael(document.createElement('DIV'), 100, 100);
+            lineTypeBase.dimension = {
+                width: 100,
+                height: 100
+            };
+            lineTypeBase.position = {
+                left: 30,
+                top: 40
+            };
+            lineTypeBase.animate(() => {}, []);
+
+            const [callArgument] = lineTypeBase.clipRect.attr.calls.mostRecent().args;
+
+            expect(callArgument.x).toBe(20);
+            expect(callArgument.x).toBe(30);
+        });
+    });
 });


### PR DESCRIPTION
## 증상
라인, 에어리어 차트에서 rerender나 setData api 사용후 zoom 기능 사용시 자바스크립트 에러가 나타나는 경우가 있음.


## 원인
1. 라인 에어리어 타입 차트의 animate를 위한 clipRect 영역의 x, y 포지션이 한번 생성되면  rerender시에는 업데이트 되지 않는 문제가 있음 
2. rerender 시에 `this.positionMap` left, top 포지션이 갱신되지 않아 이벤트 포지션 계산이 어긋나는 문제가 있음

## 해결
1. animate를 위한 clipRect 영역의 animate시 항상 x, y 포지션을 새로 세팅해줌.
2. 차트 rerender시 `this.positionMap` 값을 새로운 값으로 갱신해주도록 함
