### PR TITLE
Fix/combochart line series tooltip

### DIFF
--- a/src/js/components/series/lineTypeSeriesBase.js
+++ b/src/js/components/series/lineTypeSeriesBase.js
@@ -249,8 +249,7 @@ class LineTypeSeriesBase {
      * To call hideGroupTooltipLine function of graphRenderer.
      */
     onHideGroupTooltipLine() {
-        const existSeriesData = this.seriesData && this.seriesData.length > 0;
-        if (!existSeriesData
+        if (!this.seriesData
             || !this.seriesData.isAvailable()
             || !this.graphRenderer.hideGroupTooltipLine
         ) {

--- a/src/js/components/series/lineTypeSeriesBase.js
+++ b/src/js/components/series/lineTypeSeriesBase.js
@@ -249,7 +249,8 @@ class LineTypeSeriesBase {
      * To call hideGroupTooltipLine function of graphRenderer.
      */
     onHideGroupTooltipLine() {
-        if (!this.seriesData
+        const existSeriesData = this.seriesData && this.seriesData.length > 0;
+        if (!existSeriesData
             || !this.seriesData.isAvailable()
             || !this.graphRenderer.hideGroupTooltipLine
         ) {

--- a/src/js/components/series/lineTypeSeriesBase.js
+++ b/src/js/components/series/lineTypeSeriesBase.js
@@ -249,10 +249,7 @@ class LineTypeSeriesBase {
      * To call hideGroupTooltipLine function of graphRenderer.
      */
     onHideGroupTooltipLine() {
-        if (!this.seriesData
-            || !this.seriesData.isAvailable()
-            || !this.graphRenderer.hideGroupTooltipLine
-        ) {
+        if (!this.isAvailableSeriesData() || !this.graphRenderer.hideGroupTooltipLine) {
             return;
         }
         this.graphRenderer.hideGroupTooltipLine();

--- a/src/js/components/series/series.js
+++ b/src/js/components/series/series.js
@@ -105,9 +105,9 @@ class Series {
 
         /**
          * series data
-         * @type {Array.<object>}
+         * @type {object}
          */
-        this.seriesData = [];
+        this.seriesData = {};
 
         /**
          * Selected legend index
@@ -449,7 +449,9 @@ class Series {
             this.labelSet.remove();
         }
 
-        this.seriesData = [];
+        this.seriesData = {
+            isAvailable: () => false
+        };
     }
 
     /**

--- a/src/js/components/series/series.js
+++ b/src/js/components/series/series.js
@@ -449,9 +449,7 @@ class Series {
             this.labelSet.remove();
         }
 
-        this.seriesData = {
-            isAvailable: () => false
-        };
+        this.seriesData = {};
     }
 
     /**
@@ -808,6 +806,10 @@ class Series {
             dom.removeClass(this.seriesLabelContainer, 'show');
             dom.removeClass(this.seriesLabelContainer, 'opacity');
         }
+    }
+
+    isAvailableSeriesData() {
+        return !!(this.seriesData && this.seriesData.isAvailable && this.seriesData.isAvailable());
     }
 
     /**

--- a/test/components/series/lineTypeSeriesBase.spec.js
+++ b/test/components/series/lineTypeSeriesBase.spec.js
@@ -36,6 +36,18 @@ describe('LineTypeSeriesBase', () => {
         };
     });
 
+    describe('onHideGroupTooltipLine()', () => {
+        it('Should be returned before executing HideGroupTooltipLine when series data is empty', () => {
+            series.graphRenderer = {
+                hideGroupTooltipLine: jasmine.createSpy('hideGroupTooltipLine')
+            };
+            series.seriesData = [];
+            series.onHideGroupTooltipLine();
+
+            expect(series.graphRenderer.hideGroupTooltipLine).not.toHaveBeenCalled();
+        });
+    });
+
     describe('_renderSeriesLabel()', () => {
         const paper = raphael(dom.create('div'), 100, 100);
         const seriesDataModel = new SeriesDataModel();

--- a/test/components/series/lineTypeSeriesBase.spec.js
+++ b/test/components/series/lineTypeSeriesBase.spec.js
@@ -36,18 +36,6 @@ describe('LineTypeSeriesBase', () => {
         };
     });
 
-    describe('onHideGroupTooltipLine()', () => {
-        it('Should be returned before executing HideGroupTooltipLine when series data is empty', () => {
-            series.graphRenderer = {
-                hideGroupTooltipLine: jasmine.createSpy('hideGroupTooltipLine')
-            };
-            series.seriesData = [];
-            series.onHideGroupTooltipLine();
-
-            expect(series.graphRenderer.hideGroupTooltipLine).not.toHaveBeenCalled();
-        });
-    });
-
     describe('_renderSeriesLabel()', () => {
         const paper = raphael(dom.create('div'), 100, 100);
         const seriesDataModel = new SeriesDataModel();

--- a/test/components/series/series.spec.js
+++ b/test/components/series/series.spec.js
@@ -29,6 +29,14 @@ describe('Series', () => {
         });
     });
 
+    describe('_clearSeriesContainer', () => {
+        it('Default value of `isAvailable ()` should be false.', () => {
+            series._clearSeriesContainer();
+
+            expect(series.seriesData.isAvailable()).toBe(false);
+        });
+    });
+
     describe('presetForChangeData()', () => {
         const theme = {
             label: {

--- a/test/components/series/series.spec.js
+++ b/test/components/series/series.spec.js
@@ -30,10 +30,10 @@ describe('Series', () => {
     });
 
     describe('_clearSeriesContainer', () => {
-        it('seriesData value must be initialized to null', () => {
+        it('seriesData value must be initialized to empty object', () => {
             series._clearSeriesContainer();
 
-            expect(series.hasDataForRendering(series.seriesData)).toBe(false);
+            expect(series.seriesData).toEqual({});
         });
     });
 

--- a/test/components/series/series.spec.js
+++ b/test/components/series/series.spec.js
@@ -30,10 +30,10 @@ describe('Series', () => {
     });
 
     describe('_clearSeriesContainer', () => {
-        it('Default value of `isAvailable ()` should be false.', () => {
+        it('seriesData value must be initialized to null', () => {
             series._clearSeriesContainer();
 
-            expect(series.seriesData.isAvailable()).toBe(false);
+            expect(series.hasDataForRendering(series.seriesData)).toBe(false);
         });
     });
 


### PR DESCRIPTION
## 증상
* https://nhnent.dooray.com/project/to/2399809801432542416
라인 & 컬럼 콤보차트에서 아래와 같이 라인차트에 해당하는 값이 체크를 풀어줄 경우 라인그래프에 해당하는 데이터가 없어지므로 lineSeries.seriesData 값이 빈 배열로 초기화 되고, 툴팁관련 메서드에서 seriesData값에 접근할 경우 lineSeries.seriesData.isAvailable() 메서드를 찾을 수 없어서 에러가 난다.
![2019-01-28 10 56 25](https://user-images.githubusercontent.com/35218826/51810477-5f1e7000-22eb-11e9-9c55-ff00791e2838.png)

## 해결
series.seriesData는 데이터 타입은 배열이 아닌데 배열로 되어 있는 문제가 있으므로, 값 정의를 명확히 해주고
series._clearSeriesContainer() 메서드로 seriesData 값을 초기화해줄때도
꼭 있어야 하는 .isAvailable() 메서드의 디폴트 리턴값을 false로 리턴하도록 해줌. 
