### PR TITLE
fix: Change chart export type to default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -752,5 +752,5 @@ declare namespace tuiChart {
 }
 
 declare module 'tui-chart' {
-    export = tuiChart;
+    export default tuiChart;
 }

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
     "noEmit": true,
-    "noImplicitAny": false,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "noImplicitAny": false
   },
   "include": [
     "../../index.d.ts",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

Remove **esModuleInterop**, **allowSyntheticDefaultImports** options in `tsconfig.json`.
Change 'tui-chart' class export type to `default` in `index.d.ts`.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨